### PR TITLE
Some updates to the downloads page

### DIFF
--- a/templates/downloads.html
+++ b/templates/downloads.html
@@ -18,7 +18,6 @@
             <h3>
             <i class="fa fa-windows fa-2x"></i>
             Picard for <strong>Windows</strong>
-            <span>1.2</span>
             </h3>
 
             <div class="table-responsive">
@@ -47,6 +46,16 @@
                       </div>
                     </td>
                   </tr>
+                  <tr>
+                    <td>1.3 (Unstable)</td>
+                    <td>-</td>
+                    <td>~9 MB</td>
+                    <td>
+                      <div class="btn-group">
+                        <a href="http://build.oxygene.sk/job/package-picard-win-daily/">Daily Builds for Windows</a>
+                      </div>
+                    </td>
+                  </tr>
                 </tbody>
               </table>
             </div>
@@ -59,7 +68,6 @@
             <h3>
             <i class="fa fa-apple fa-2x"></i>
             Picard for <strong>Mac OS X</strong>
-            <span>1.2</span>
             </h3>
 
             <div class="table-responsive">
@@ -103,6 +111,16 @@
                       </div>
                     </td>
                   </tr>
+                  <tr>
+                    <td>Picard 1.3 (Unstable)</td>
+                    <td>-</td>
+                    <td>~17 MB</td>
+                    <td>
+                      <div class="btn-group">
+                        <a href="http://build.oxygene.sk/job/package-picard-osx-daily/">Daily Builds for OSX</a>
+                      </div>
+                    </td>
+                  </tr>
                 </tbody>
               </table>
             </div>
@@ -113,7 +131,6 @@
             <h3>
             <i class="fa fa-linux fa-2x"></i>
             Picard for <strong>Linux</strong>
-            <span>1.2</span>
             </h3>
 
             <div class="table-responsive">
@@ -130,7 +147,7 @@
                     <td>
                       <a href="https://launchpad.net/~musicbrainz-developers/+archive/stable">MusicBrainz Stable PPA</a>
                       &middot
-                      <a href="https://launchpad.net/~musicbrainz-developers/+archive/daily">MusicBrainz Daily PPA</a>
+                      <a href="https://launchpad.net/~musicbrainz-developers/+archive/daily">MusicBrainz Daily PPA (Unstable)</a>
                     </td>
                   </tr>
                   <tr>
@@ -153,6 +170,12 @@
                       <a href="http://packages.gentoo.org/package/media-sound/picard">media-sound/picard</a>
                     </td>
                   </tr>
+                  <tr>
+                    <td>Others</td>
+                    <td>
+                      <a href="https://musicbrainz.org/doc/Picard_Linux_Install">Read the documentation</a>
+                    </td>
+                  </tr>
                 </tbody>
               </table>
             </div>
@@ -163,7 +186,6 @@
             <h3>
             <i class="fa fa-code fa-2x"></i>
             Picard <strong>Source Code</strong>
-            <span>1.2</span>
             </h3>
 
             <div class="table-responsive">


### PR DESCRIPTION
Added links to daily builds of Picard. It'd be nice if we could have
direct links to the executables (but I don't think that's possible.)

Removed the Picard version from titles.

Added a doc link to install Picard on different Linux flavours.
