### PR TITLE
Update Cover art options description

### DIFF
--- a/templates/docs/options.html
+++ b/templates/docs/options.html
@@ -282,7 +282,7 @@
         Front (cover) for that.
       </p>
       <p>Since Picard 1.3, you can also decide to use the image from the release group (if any) if no front
-        image is found for the release. In this case, the cover may not matched the exact release you are
+        image is found for the release. In this case, the cover may not match the exact release you are
         tagging (eg. a 1979 vinyl front cover may be used in place of the Deluxe 2010 CD reissue).
       </p>
 


### PR DESCRIPTION
- typo fixes
- remove reference to the old plugin (<1.2)
- add a note about 1.3 release group image fallback option
