### PR TITLE
Add a download link to the plugins table.

### DIFF
--- a/website/frontend/messages.pot
+++ b/website/frontend/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2014-10-20 22:32+0200\n"
+"POT-Creation-Date: 2014-12-04 15:54+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -160,6 +160,8 @@ msgstr ""
 #: website/frontend/templates/downloads.html:86
 #: website/frontend/templates/downloads.html:134
 #: website/frontend/templates/downloads.html:227
+#: website/frontend/templates/downloads.html:242
+#: website/frontend/templates/plugins.html:34
 msgid "Download"
 msgstr ""
 
@@ -179,6 +181,7 @@ msgstr ""
 
 #: website/frontend/templates/downloads.html:45
 #: website/frontend/templates/downloads.html:96
+#: website/frontend/templates/downloads.html:237
 msgid "occasionally unstable"
 msgstr ""
 
@@ -228,7 +231,7 @@ msgstr ""
 msgid "Picard <strong>Source Code</strong>"
 msgstr ""
 
-#: website/frontend/templates/downloads.html:242
+#: website/frontend/templates/downloads.html:257
 msgid ""
 "This page lists the most recent downloads. If you're looking for older "
 "versions of Picard, {url|browse our FTP server}."
@@ -314,19 +317,19 @@ msgid ""
 "{urlrepo|repository}."
 msgstr ""
 
-#: website/frontend/templates/plugins.html:18
+#: website/frontend/templates/plugins.html:19
 msgid "Name"
 msgstr ""
 
-#: website/frontend/templates/plugins.html:19
+#: website/frontend/templates/plugins.html:20
 msgid "Version"
 msgstr ""
 
-#: website/frontend/templates/plugins.html:20
+#: website/frontend/templates/plugins.html:21
 msgid "Description"
 msgstr ""
 
-#: website/frontend/templates/plugins.html:21
+#: website/frontend/templates/plugins.html:22
 msgid "Author(s)"
 msgstr ""
 

--- a/website/frontend/static/css/styles.css
+++ b/website/frontend/static/css/styles.css
@@ -5266,6 +5266,9 @@ a :focus {
   outline: none !important;
   text-decoration: underline;
 }
+a.btn-primary:visited {
+  color: #ffffff;
+}
 .navbar {
   margin: 0px;
   border-width: 0 0 5px;

--- a/website/frontend/static/less/site-wide.less
+++ b/website/frontend/static/less/site-wide.less
@@ -11,6 +11,11 @@ a
       outline: none !important;
       text-decoration: underline;
    }
+
+   &.btn-primary:visited
+   {
+      color: @btn-primary-color;
+   }
 }
 
 .navbar

--- a/website/frontend/templates/plugins.html
+++ b/website/frontend/templates/plugins.html
@@ -13,12 +13,14 @@
             <col width="100px" name="Version"/>
             <col width="500px" name="Description"/>
             <col width="150px" name="Author"/>
+            <col width="100px" name="Download"/>
             <thead>
               <tr>
                 <th class="text-center">{{ _("Name") }}</th>
                 <th class="text-center">{{ _("Version") }}</th>
                 <th class="text-center">{{ _("Description") }}</th>
                 <th class="text-center">{{ _("Author(s)") }}</th>
+                <th class="text-center"></th>
               </tr>
             </thead>
             <tbody>
@@ -28,6 +30,9 @@
               <td>{{ plugin["version"] }}</td>
               <td>{{ plugin["description"] | safe }}</td>
               <td>{{ plugin["author"] }}</td>
+              <td class="text-center">
+                <a class="btn btn-primary btn-sm" href="/api/v1/download?id={{ id }}">{{ _("Download") }}</a>
+              </td>
             </tr>
             {% endfor %}
             </tbody>


### PR DESCRIPTION
This is meant to be a temporary solution until a Picard version supporting the plugins API gets released. But maybe we even want to keep those links later on for those who don't want to or cannot use the builtin plugin management.
