### PR TITLE
Implement plugin api v2 endpoints

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,8 +40,7 @@ RUN pybabel compile -d website/frontend/translations
 RUN ./node_modules/.bin/gulp
 
 # Plugins
-RUN git clone https://github.com/metabrainz/picard-plugins.git /code/plugins
-RUN cd /code/plugins && python generate.py
+RUN fab plugins_generate
 
 RUN apt-get purge -y $BUILD_DEPS && \
     apt-get autoremove -y

--- a/fabfile.py
+++ b/fabfile.py
@@ -1,11 +1,9 @@
 from __future__ import with_statement
 from fabric.api import local
-from fabric.colors import green, yellow
-from fabric.context_managers import lcd
-from fabric.contrib.console import confirm
+from fabric.colors import green
 from fabric.utils import abort
+from website.build_plugins import generate_plugins
 import website.frontend
-import os.path
 
 
 def extract_strings():
@@ -62,20 +60,13 @@ def plugins_generate():
 
     Clone or pull repository from GitHub and run generate.py script
     """
-    repo = website.frontend.create_app().config['PLUGINS_REPOSITORY']
-    versions = website.frontend.create_app().config['PLUGIN_VERSIONS']
-    if not os.path.isdir(repo):
-        print(yellow("'%s' directory defined by PLUGINS_REPOSITORY doesn't exist" % repo))
-        if confirm("Do you want to clone picard-plugins from GitHub?"):
-            local('git clone https://github.com/musicbrainz/picard-plugins/ %s' %
-              repo)
-        else:
-            abort('Aborting...')
-    with lcd(repo):
-        local("git pull")
-        for version in versions:
-            local("python generate.py %s" % version)
-            print(green("Plugins files for version %s have been generated successfully." % version, bold=True))
+    config = website.frontend.create_app().config
+    versions = config['PLUGIN_VERSIONS'].values()
+    build_dir = config['PLUGINS_BUILD_DIR']
+    for version in versions:
+        print(build_dir, version)
+        generate_plugins(build_dir, version)
+        print(green("Plugins files for version %s have been generated successfully." % version, bold=True))
 
 
 def deploy():

--- a/fabfile.py
+++ b/fabfile.py
@@ -63,6 +63,7 @@ def plugins_generate():
     Clone or pull repository from GitHub and run generate.py script
     """
     repo = website.frontend.create_app().config['PLUGINS_REPOSITORY']
+    versions = website.frontend.create_app().config['PLUGIN_VERSIONS']
     if not os.path.isdir(repo):
         print(yellow("'%s' directory defined by PLUGINS_REPOSITORY doesn't exist" % repo))
         if confirm("Do you want to clone picard-plugins from GitHub?"):
@@ -72,8 +73,9 @@ def plugins_generate():
             abort('Aborting...')
     with lcd(repo):
         local("git pull")
-        local("python generate.py")
-        print(green("Plugins files have been generated successfully.", bold=True))
+        for version in versions:
+            local("python generate.py %s" % version)
+            print(green("Plugins files for version %s have been generated successfully." % version, bold=True))
 
 
 def deploy():

--- a/website/build_plugins.py
+++ b/website/build_plugins.py
@@ -155,6 +155,9 @@ def download_plugins(version=None):
 
 def generate_plugins(build_dir, version=None, json=True, zips=True):
     """Download and generate plugin build files for a given version"""
+    # Return if both are False
+    if not (json or zips):
+        return
     dest_dir = os.path.abspath(os.path.join(build_dir, version or ''))
     try:
         temp_dir, source_dir = download_plugins(version)

--- a/website/build_plugins.py
+++ b/website/build_plugins.py
@@ -1,0 +1,167 @@
+# -*- coding: utf-8 -*-
+
+import ast
+import os
+import json
+import shutil
+import zipfile
+
+from hashlib import md5
+from tempfile import mkdtemp
+# for Py2/3 compatibility
+try:
+    from urllib import urlretrieve
+except ImportError:
+    from urllib.request import urlretrieve
+
+PLUGIN_DOWNLOAD_URL = "https://github.com/metabrainz/picard-plugins/archive/%s.zip"
+
+# The file that contains json data
+PLUGIN_FILE_NAME = "plugins.json"
+
+# The directory that contains the plugin files in upstream
+PLUGIN_DIR = "plugins"
+
+VERSION_TO_BRANCH = {
+    None: 'master',
+    '1.0': 'master',
+    '2.0': '2.0',
+}
+
+KNOWN_DATA = [
+    'PLUGIN_NAME',
+    'PLUGIN_AUTHOR',
+    'PLUGIN_VERSION',
+    'PLUGIN_API_VERSIONS',
+    'PLUGIN_LICENSE',
+    'PLUGIN_LICENSE_URL',
+    'PLUGIN_DESCRIPTION',
+]
+
+
+def get_plugin_data(filepath):
+    """Parse a python file and return a dict with plugin metadata"""
+    data = {}
+    with open(filepath, 'rU') as plugin_file:
+        source = plugin_file.read()
+        try:
+            root = ast.parse(source, filepath)
+        except Exception:
+            print("Cannot parse " + filepath)
+            raise
+        for node in ast.iter_child_nodes(root):
+            if isinstance(node, ast.Assign) and len(node.targets) == 1:
+                target = node.targets[0]
+                if (isinstance(target, ast.Name)
+                    and isinstance(target.ctx, ast.Store)
+                        and target.id in KNOWN_DATA):
+                    name = target.id.replace('PLUGIN_', '', 1).lower()
+                    if name not in data:
+                        try:
+                            data[name] = ast.literal_eval(node.value)
+                        except ValueError:
+                            print('Cannot evaluate value in '
+                                  + filepath + ':' +
+                                  ast.dump(node))
+        return data
+
+
+def build_json(source_dir, dest_dir):
+    """Traverse the plugins directory to generate json data."""
+
+    plugins = {}
+
+    # All top level directories in source_dir are plugins
+    for dirname in next(os.walk(source_dir))[1]:
+
+        files = {}
+        data = {}
+
+        if dirname in [".git"]:
+            continue
+
+        dirpath = os.path.join(source_dir, dirname)
+        for root, dirs, filenames in os.walk(dirpath):
+            for filename in filenames:
+                ext = os.path.splitext(filename)[1]
+
+                if ext not in [".pyc"]:
+                    file_path = os.path.join(root, filename)
+                    with open(file_path, "rb") as md5file:
+                        md5Hash = md5(md5file.read()).hexdigest()
+                    files[file_path.split(os.path.join(dirpath, ''))[1]] = md5Hash
+
+                    if ext in ['.py'] and not data:
+                        data = get_plugin_data(os.path.join(source_dir, dirname, filename))
+
+        if files and data:
+            print("Added: " + dirname)
+            data['files'] = files
+            plugins[dirname] = data
+    out_path = os.path.join(dest_dir, PLUGIN_FILE_NAME)
+    with open(out_path, "w") as out_file:
+        json.dump({"plugins": plugins}, out_file, sort_keys=True, indent=2)
+
+
+def zip_files(source_dir, dest_dir):
+    """Zip up plugin folders"""
+
+    for dirname in next(os.walk(source_dir))[1]:
+        archive_path = os.path.join(dest_dir, dirname)
+        archive = zipfile.ZipFile(archive_path + ".zip", "w")
+
+        dirpath = os.path.join(source_dir, dirname)
+        plugin_files = []
+
+        for root, dirs, filenames in os.walk(dirpath):
+            for filename in filenames:
+                file_path = os.path.join(root, filename)
+                plugin_files.append(file_path)
+
+        if len(plugin_files) == 1:
+            # There's only one file, put it directly into the zipfile
+            archive.write(plugin_files[0],
+                          os.path.basename(plugin_files[0]),
+                          compress_type=zipfile.ZIP_DEFLATED)
+        else:
+            for filename in plugin_files:
+                # Preserve the folder structure relative to source_dir
+                # in the zip file
+                name_in_zip = os.path.join(os.path.relpath(filename,
+                                                           source_dir))
+                archive.write(filename,
+                              name_in_zip,
+                              compress_type=zipfile.ZIP_DEFLATED)
+
+        print("Created: " + dirname + ".zip")
+
+
+def download_plugins(version=None):
+    """Downloads and extracts the plugin source files"""
+    temp_dir = mkdtemp(suffix="PICARD-WEBSITE")
+    source_path = os.path.join(temp_dir, version or '')
+    zip_path = source_path + ".zip"
+
+    download_url = PLUGIN_DOWNLOAD_URL % (VERSION_TO_BRANCH[version])
+    print("Downloading files. Please wait....")
+    urlretrieve(download_url, zip_path)
+
+    zip_file = zipfile.ZipFile(zip_path)
+    zip_file.extractall(source_path)
+
+    source_dir = os.path.join(source_path, zip_file.namelist()[0], PLUGIN_DIR)
+    return temp_dir, source_dir
+
+
+def generate_plugins(build_dir, version=None, json=True, zips=True):
+    """Download and generate plugin build files for a given version"""
+    dest_dir = os.path.abspath(os.path.join(build_dir, version or ''))
+    temp_dir, source_dir = download_plugins(version)
+    if not os.path.exists(dest_dir):
+        os.makedirs(dest_dir)
+    if json:
+        build_json(source_dir, dest_dir)
+    if zips:
+        zip_files(source_dir, dest_dir)
+
+    shutil.rmtree(temp_dir)

--- a/website/build_plugins.py
+++ b/website/build_plugins.py
@@ -156,12 +156,18 @@ def download_plugins(version=None):
 def generate_plugins(build_dir, version=None, json=True, zips=True):
     """Download and generate plugin build files for a given version"""
     dest_dir = os.path.abspath(os.path.join(build_dir, version or ''))
-    temp_dir, source_dir = download_plugins(version)
-    if not os.path.exists(dest_dir):
-        os.makedirs(dest_dir)
-    if json:
-        build_json(source_dir, dest_dir)
-    if zips:
-        zip_files(source_dir, dest_dir)
-
-    shutil.rmtree(temp_dir)
+    try:
+        temp_dir, source_dir = download_plugins(version)
+        if not os.path.exists(dest_dir):
+            os.makedirs(dest_dir)
+        if json:
+            build_json(source_dir, dest_dir)
+        if zips:
+            zip_files(source_dir, dest_dir)
+    except Exception as e:
+        print(e)
+    finally:
+        try:
+            shutil.rmtree(temp_dir)
+        except OSError:
+            pass

--- a/website/build_plugins_test.py
+++ b/website/build_plugins_test.py
@@ -1,0 +1,98 @@
+import os
+import glob
+import json
+import shutil
+import tempfile
+import unittest
+from website.build_plugins import download_plugins, build_json, zip_files
+
+# python 2 & 3 compatibility
+try:
+    basestring
+except NameError:
+    basestring = str
+
+
+class GenerateTestCase(unittest.TestCase):
+
+    """Run tests"""
+
+    # The file that contains json data
+    PLUGIN_FILE = "plugins.json"
+
+    # The directory which contains plugin files
+    @classmethod
+    def setUpClass(cls):
+        cls.temp_dir, cls.plugin_dir = download_plugins()
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.temp_dir)
+
+    def setUp(self):
+        # Destination directory
+        self.dest_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.dest_dir)
+        self.plugin_file = os.path.join(self.dest_dir, self.PLUGIN_FILE)
+
+    def test_generate_json(self):
+        """
+        Generates the json data from all the plugins
+        and asserts that all plugins are accounted for.
+        """
+
+        print("\n#########################################\n")
+
+        build_json(self.plugin_dir, self.dest_dir)
+
+        # Load the json file
+        with open(self.plugin_file, "r") as in_file:
+            plugin_json = json.load(in_file)["plugins"]
+
+        # All top level directories in plugin_dir
+        plugin_folders = next(os.walk(self.plugin_dir))[1]
+
+        # Number of entries in the json should be equal to the
+        # number of folders in plugin_dir
+        self.assertEqual(len(plugin_json), len(plugin_folders))
+
+    def test_generate_zip(self):
+        """
+        Generates zip files for all folders and asserts
+        that all folders are accounted for.
+        """
+
+        print("\n\n#########################################\n")
+
+        zip_files(self.plugin_dir, self.dest_dir)
+
+        # All zip files in plugin_dir
+        plugin_zips = glob.glob(os.path.join(self.dest_dir, "*.zip"))
+
+        # All top level directories in plugin_dir
+        plugin_folders = next(os.walk(self.plugin_dir))[1]
+
+        # Number of folders should be equal to number of zips
+        self.assertEqual(len(plugin_zips), len(plugin_folders))
+
+    def test_valid_json(self):
+        """
+        Asserts that the json data contains all the fields
+        for all the plugins.
+        """
+
+        print("\n#########################################\n")
+
+        build_json(self.plugin_dir, self.dest_dir)
+
+        # Load the json file
+        with open(self.plugin_file, "r") as in_file:
+            plugin_json = json.load(in_file)["plugins"]
+
+        # All plugins should contain all required fields
+        for module_name, data in plugin_json.items():
+            self.assertIsInstance(data['name'], basestring)
+            self.assertIsInstance(data['api_versions'], list)
+            self.assertIsInstance(data['author'], basestring)
+            self.assertIsInstance(data['description'], basestring)
+            self.assertIsInstance(data['version'], basestring)

--- a/website/build_plugins_test.py
+++ b/website/build_plugins_test.py
@@ -27,12 +27,19 @@ class GenerateTestCase(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        shutil.rmtree(cls.temp_dir)
+        try:
+            shutil.rmtree(cls.temp_dir)
+        except OSError as e:
+            print(e)
 
     def setUp(self):
         # Destination directory
-        self.dest_dir = tempfile.mkdtemp()
-        self.addCleanup(shutil.rmtree, self.dest_dir)
+        try:
+            self.dest_dir = tempfile.mkdtemp()
+        except OSError as e:
+            print(e)
+        else:
+            self.addCleanup(shutil.rmtree, self.dest_dir)
         self.plugin_file = os.path.join(self.dest_dir, self.PLUGIN_FILE)
 
     def test_generate_json(self):

--- a/website/default_config.py
+++ b/website/default_config.py
@@ -1,4 +1,4 @@
-PLUGINS_REPOSITORY = "/media/sam/Data/dev/picard-website/code/plugins"
+PLUGINS_REPOSITORY = "/code/plugins"
 PLUGINS_CACHE_TIMEOUT = 5 * 60
 PLUGIN_VERSIONS = ['v1', 'v2']
 CHANGELOG_URL = "https://raw.githubusercontent.com/musicbrainz/picard/master/NEWS.txt"

--- a/website/default_config.py
+++ b/website/default_config.py
@@ -1,6 +1,6 @@
-PLUGINS_REPOSITORY = "/code/plugins"
+PLUGINS_REPOSITORY = "/media/sam/Data/dev/picard-website/code/plugins"
 PLUGINS_CACHE_TIMEOUT = 5 * 60
-
+PLUGIN_VERSIONS = ['v1', 'v2']
 CHANGELOG_URL = "https://raw.githubusercontent.com/musicbrainz/picard/master/NEWS.txt"
 CHANGELOG_CACHE_TIMEOUT = 5 * 60
 

--- a/website/default_config.py
+++ b/website/default_config.py
@@ -1,4 +1,4 @@
-PLUGINS_BUILD_DIR = "/plugins"
+PLUGINS_BUILD_DIR = "/code/plugins"
 PLUGINS_CACHE_TIMEOUT = 5 * 60
 PLUGIN_VERSIONS = {
     'v1': '1.0',

--- a/website/default_config.py
+++ b/website/default_config.py
@@ -1,5 +1,8 @@
 PLUGINS_BUILD_DIR = "/code/plugins"
 PLUGINS_CACHE_TIMEOUT = 5 * 60
+# Flask automatically orders them in ascending order while
+# retrieveing them. Since it is a string comparison, v10 appears before
+# v2. So be careful with the ordering.
 PLUGIN_VERSIONS = {
     'v1': '1.0',
     'v2': '2.0',

--- a/website/default_config.py
+++ b/website/default_config.py
@@ -1,6 +1,9 @@
-PLUGINS_REPOSITORY = "/code/plugins"
+PLUGINS_BUILD_DIR = "/plugins"
 PLUGINS_CACHE_TIMEOUT = 5 * 60
-PLUGIN_VERSIONS = ['v1', 'v2']
+PLUGIN_VERSIONS = {
+    'v1': '1.0',
+    'v2': '2.0',
+}
 CHANGELOG_URL = "https://raw.githubusercontent.com/musicbrainz/picard/master/NEWS.txt"
 CHANGELOG_CACHE_TIMEOUT = 5 * 60
 

--- a/website/frontend/errors.py
+++ b/website/frontend/errors.py
@@ -12,7 +12,6 @@ def init_error_handlers(app):
     def not_found_handler(error):
         if request.path.startswith("/api"):
             return make_response(
-                jsonify({"message": "The two endpoints currently available"
-                        " are /api/v1/plugins and /api/v1/download"}), 404)
+                jsonify({"message": "No API version specified"}), 404)
 
         return render_template('errors/404.html', error=error), 404

--- a/website/frontend/templates/plugins.html
+++ b/website/frontend/templates/plugins.html
@@ -31,7 +31,7 @@
                 <td>{{ plugin["name"] }}</td>
                 <td>{{ plugin["version"] }}</td>
                 <td>{{ plugin["description"] | safe }}</td>
-                <td>{{ plugin["author"] }}</td>
+                <td>{{ plugin["author"] | safe}}</td>
                 <td class="text-center">
                   <a class="btn btn-primary btn-sm" href="/api/v1/download?id={{ id }}">{{ _("Download") }}</a>
                 </td>

--- a/website/frontend/templates/plugins.html
+++ b/website/frontend/templates/plugins.html
@@ -7,37 +7,40 @@
         {% autoescape false %}
         <p>{{ _("This is a list of plugins that are currently available for use with Picard. The table is generated from the data of our plugin {urlrepo|repository}.")|expand({"urlrepo": "https://github.com/musicbrainz/picard-plugins"}) }}</p>
         {% endautoescape %}
-        <div class="table-responsive">
-          <table class="table table-bordered table-hover">
-            <col width="175px" name="Name"/>
-            <col width="100px" name="Version"/>
-            <col width="500px" name="Description"/>
-            <col width="150px" name="Author"/>
-            <col width="100px" name="Download"/>
-            <thead>
+        {% for version, plugins in all_plugins.items() %}
+        <h3>API Version: <strong>{{version}}</strong></h3>
+          <div class="table-responsive">
+            <table class="table table-bordered table-hover">
+              <col width="175px" name="Name"/>
+              <col width="100px" name="Version"/>
+              <col width="500px" name="Description"/>
+              <col width="150px" name="Author"/>
+              <col width="100px" name="Download"/>
+              <thead>
+                <tr>
+                  <th class="text-center">{{ _("Name") }}</th>
+                  <th class="text-center">{{ _("Version") }}</th>
+                  <th class="text-center">{{ _("Description") }}</th>
+                  <th class="text-center">{{ _("Author(s)") }}</th>
+                  <th class="text-center"></th>
+                </tr>
+              </thead>
+              <tbody>
+              {% for id, plugin in plugins.items() %}
               <tr>
-                <th class="text-center">{{ _("Name") }}</th>
-                <th class="text-center">{{ _("Version") }}</th>
-                <th class="text-center">{{ _("Description") }}</th>
-                <th class="text-center">{{ _("Author(s)") }}</th>
-                <th class="text-center"></th>
+                <td>{{ plugin["name"] }}</td>
+                <td>{{ plugin["version"] }}</td>
+                <td>{{ plugin["description"] | safe }}</td>
+                <td>{{ plugin["author"] }}</td>
+                <td class="text-center">
+                  <a class="btn btn-primary btn-sm" href="/api/v1/download?id={{ id }}">{{ _("Download") }}</a>
+                </td>
               </tr>
-            </thead>
-            <tbody>
-            {% for id, plugin in plugins.items() %}
-            <tr>
-              <td>{{ plugin["name"] }}</td>
-              <td>{{ plugin["version"] }}</td>
-              <td>{{ plugin["description"] | safe }}</td>
-              <td>{{ plugin["author"] }}</td>
-              <td class="text-center">
-                <a class="btn btn-primary btn-sm" href="/api/v1/download?id={{ id }}">{{ _("Download") }}</a>
-              </td>
-            </tr>
-            {% endfor %}
-            </tbody>
-          </table>
-        </div>
+              {% endfor %}
+              </tbody>
+            </table>
+          </div>
+        {% endfor %}
       </div>
-{% endblock %}
     </div>
+{% endblock %}

--- a/website/frontend/views/api.py
+++ b/website/frontend/views/api.py
@@ -112,6 +112,6 @@ def download_plugin(version):
         else:
             return make_response(
                 jsonify({'error': 'Plugin id not specified.',
-                         'message': 'Correct usage: /api/v1/download?id=<id>'}), 400)
+                         'message': 'Correct usage: /api/%s/download?id=<id>' % version}), 400)
     else:
         return invalid_api_version(404)

--- a/website/frontend/views/api.py
+++ b/website/frontend/views/api.py
@@ -91,7 +91,7 @@ def get_plugin(version):
     """
     build_version = get_build_version(current_app, version)
     if build_version:
-        pid = request.args.get('id', None)
+        pid = request.args.get('id')
         return _get_plugin(current_app, build_version, pid)
     else:
         return invalid_api_version(404)
@@ -106,7 +106,7 @@ def download_plugin(version):
     """
     build_version = get_build_version(current_app, version)
     if build_version:
-        pid = request.args.get('id', None)
+        pid = request.args.get('id')
         if pid:
             return _download_plugin(current_app, build_version, pid)
         else:

--- a/website/frontend/views/api_test.py
+++ b/website/frontend/views/api_test.py
@@ -16,7 +16,7 @@ class ViewsTestCase(FrontendTestCase):
     # api
 
     def test_api_404(self):
-        response = self.client.get("/api/404")
+        response = self.client.get("/api/404/")
         self.assert404(response)
 
     def test_api_root(self):
@@ -30,7 +30,7 @@ class ViewsTestCase(FrontendTestCase):
     def test_api_v1_redirect(self):
         "Test /api/v1"
         response = self.client.get("/api/v1")
-        self.assertRedirects(response, url_for("api.api_root"))
+        self.assertRedirects(response, url_for("api.api_root", version='v1'))
 
     def test_api_v1(self):
         "Test /api/v1/"
@@ -44,7 +44,7 @@ class ViewsTestCase(FrontendTestCase):
     def test_api_v1_plugins(self):
         "Test plugins list redirection"
         response = self.client.get("/api/v1/plugins")
-        self.assertRedirects(response, url_for("api.get_plugin"))
+        self.assertRedirects(response, url_for("api.get_plugin", version='v1'))
 
     def test_api_v1_plugins(self):
         "Test plugins list"
@@ -70,7 +70,7 @@ class ViewsTestCase(FrontendTestCase):
     def test_api_v1_download_with_id_redirect(self):
         "Test download redirection"
         response = self.client.get("/api/v1/download")
-        self.assertRedirects(response, url_for("api.download_plugin"))
+        self.assertRedirects(response, url_for("api.download_plugin", version='v1'))
 
     def test_api_v1_download_with_id_not_found(self):
         "Test download with invalid plugin id"

--- a/website/frontend/views/api_test.py
+++ b/website/frontend/views/api_test.py
@@ -42,7 +42,7 @@ class ViewsTestCase(FrontendTestCase):
 
     # /v1/plugins/
 
-    def test_api_v1_plugins(self):
+    def test_api_v1_plugins_redirect(self):
         "Test plugins list redirection"
         response = self.client.get("/api/v1/plugins")
         self.assertRedirects(response, url_for("api.get_plugin", version='v1'))

--- a/website/frontend/views/api_test.py
+++ b/website/frontend/views/api_test.py
@@ -4,7 +4,8 @@ from flask import url_for
 
 _MESSAGES = {
     'plugin_not_found': 'Plugin not found.',
-    'invalid_endpoint': 'The two endpoints currently available'
+    'missing_api_version': 'No API version specified',
+    'invalid_endpoint': 'The two endpoints currently available for this api version'
                         ' are /api/v1/plugins and /api/v1/download',
     'missing_id': 'Plugin id not specified.',
     'download_usage': 'Correct usage: /api/v1/download?id=<id>',
@@ -23,7 +24,7 @@ class ViewsTestCase(FrontendTestCase):
         response = self.client.get("/api")
         self.assert404(response)
         self.assertEquals(response.json, dict(
-            message=_MESSAGES['invalid_endpoint']))
+            message=_MESSAGES['missing_api_version']))
 
     # /v1/
 

--- a/website/frontend/views/plugins.py
+++ b/website/frontend/views/plugins.py
@@ -3,17 +3,19 @@ import os
 import json
 from urllib import urlopen
 from flask import current_app, Blueprint, render_template
-
+from website.frontend.views.api import plugins_json_file
 plugins_bp = Blueprint('plugins', __name__)
 
 
 @plugins_bp.route('/')
 def show_plugins():
-    ordered_plugins = OrderedDict()
-    plugins_json_file = os.path.join(
-        current_app.config['PLUGINS_REPOSITORY'], "plugins.json")
-    with open(plugins_json_file, "r") as fp:
-        plugins = json.loads(fp.read().decode("utf-8"))['plugins']
-        for key in sorted(plugins, key=lambda k: plugins[k]['name'].lower()):
-            ordered_plugins[key] = plugins[key]
-    return render_template('plugins.html', plugins=ordered_plugins)
+    all_plugins = OrderedDict()
+    for version, build_version in sorted(current_app.config['PLUGIN_VERSIONS'].items(), reverse=True):
+        ordered_plugins = OrderedDict()
+        build_json_file = plugins_json_file(current_app, build_version)
+        with open(build_json_file, "r") as fp:
+            plugins = json.loads(fp.read().decode("utf-8"))['plugins']
+            for key in sorted(plugins, key=lambda k: plugins[k]['name'].lower()):
+                ordered_plugins[key] = plugins[key]
+        all_plugins[version[1:]] = ordered_plugins
+    return render_template('plugins.html', all_plugins=all_plugins)


### PR DESCRIPTION
This PR allows extending the plugin serving api to include multiple versions and also adds a plugin build script to generate build files from branches.

The following settings were added to the config -

* PLUGINS_BUILD_DIR: The dir where build files are generated to and accessed from.
* PLUGIN_VERSIONS: A dictionary mapping PW plugin end points to Picard plugin api versions.

The generation script provides the function generate_plugins which takes in the build dir and api version as parameters.

The generation script now downloads the zips for particular branches off off github instead of the whole repo and builds the output from there on.

The plugin display page now shows the plugins across all the api end points.