### PR TITLE
mappings: Remove empty code tags

### DIFF
--- a/website/frontend/templates/docs/mappings.html
+++ b/website/frontend/templates/docs/mappings.html
@@ -272,7 +272,6 @@
             <code>originalyear</code>
           </td>
           <td>
-            <code></code>
           </td>
           <td>
             <code>ORIGINALYEAR</code>


### PR DESCRIPTION
This created a differently colored empty section in the mapping table.