### PR TITLE
Add install instructions for Linux with Flatpak

### DIFF
--- a/website/frontend/templates/docs/linux.html
+++ b/website/frontend/templates/docs/linux.html
@@ -43,6 +43,7 @@
         </p>
         <p>or by selecting it in rpmdrake. </p>
       </span>
+    </div>
 
     <div class="col-md-4">
       <div id="sidebar" class="hidden-xs">

--- a/website/frontend/templates/docs/linux.html
+++ b/website/frontend/templates/docs/linux.html
@@ -11,6 +11,22 @@
         <a href="/downloads/#source" title="Source code for MusicBrainz Picard">here</a>.
       </p>
 
+      <h1 id="flatpak">Flatpak</h1>
+      <span>
+        <p>
+          Picard is available on <a href="https://flathub.org">Flathub</a>. This version should work on all modern
+          Linux distributions, as long <a href="http://flatpak.org/getting.html">Flatpak is installed</a>.</p>
+        </p>
+        <p>
+          First enable the Flathub repository:
+        </p>
+        <pre>flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo</pre>
+        <p>
+          You can now install Picard:
+        </p>
+        <pre>flatpak install flathub org.musicbrainz.Picard</pre>
+      </span>
+
       <h1 id="fedora">Fedora 7, 8 and Higher</h1>
       <span>
         <p>Picard is now in the official Fedora package collection: </p>
@@ -48,7 +64,8 @@
     <div class="col-md-4">
       <div id="sidebar" class="hidden-xs">
         <ul class="nav" data-spy="affix" data-offset-top="200">
-          <li class="active"><a href="#fedora">Fedora</a></li>
+          <li class="active"><a href="#flatpak">Flatpak</a></li>
+          <li><a href="#fedora">Fedora</a></li>
           <li><a href="#mandriva">Mandriva</a></li>
         </ul>
         <!-- <a class="back-to-top" href="#top"> Back to top </a> -->

--- a/website/frontend/templates/downloads.html
+++ b/website/frontend/templates/downloads.html
@@ -141,6 +141,12 @@
                 </thead>
                 <tbody>
                   <tr>
+                    <td>{{ _("All distributions") }} (Flatpak)</td>
+                    <td>
+                      <a href="{{ url_for('docs.show_pages', page='linux', _anchor='flatpak') }}">Instructions</a>
+                    </td>
+                  </tr>
+                  <tr>
                     <td>Arch Linux</td>
                     <td>
                       <a href="https://www.archlinux.org/packages/community/x86_64/picard/">Community</a>


### PR DESCRIPTION
As discussed on IRC, I've built Picard with [Flatpak](https://flatpak.org) over at Flathub.

Flatpak is a new mechanism to build and distribute desktop applications on Linux. Among other things, it provides the following:

* Cross-distribution:
    * it works on pretty much [all major Linux distributions](http://flatpak.org/getting.html)
* Bundling your dependencies with the application:
    * no more missing functionality because a Linux distro doesn't provide fpcalc/ffmpeg, the batteries are included
    * your users get exactly the bits you built and tested, not whatever versions of the libraries their distro decided to ship
* Better security:
    * application sandboxing (obviously this isn't perfect yet, especially since Picard requires Xorg; moving to Qt5/Wayland would help dramatically here)
    * builds are GPG-signed
* Smaller downloads:
    * when updating from one version to the next, users only download what changed, not the whole new bundle
* Atomic updates:
    * updating while the app is running doesn't cause weird and hard to debug issues, the new version is installed on the side while the old version continues running; closing the app and launching it again runs the new version
    * multiple versions can be installed in parallel, allowing users to test nightly versions, or even to rollback to a previous version
* Easy to build:
    * [a JSON manifest](https://github.com/flathub/org.musicbrainz.Picard/blob/master/org.musicbrainz.Picard.json) contains all the instructions for `flatpak-builder` to download the sources and build them

Flathub is a build/hosting service set up by the Flatpak community. I added Picard to it, and it now gets built on all architectures supported by Flathub: i386, x86_64 (amd64), arm and aarch64.

I'm happy to continue maintaining the Picard builds over in Flathub, although I would prefer getting this completely upstreamed so that you can take over the build yourselves, without me as a middle-man, in Flathub or on your own build machines. 😃 

---

This pull request adds the `picard.flatpakref` file which is all that is needed to install Picard with Flatpak.

With a recent GNOME version, one can simply click on the link and GNOME Software will install the application. Otherwise, installing the app is as simple as running:

```
$ flatpak install --from https://picard.musicbrainz.org/static/picard.flatpakref
```

I'm not entirely happy about the way I modified the page:

* Eventually all major desktops will support clicking on that link to install the app, but we're not there yet. (GNOME Software still has a few bugs, KDE is starting to work on adding Flatpak support to their software center but as far as I know they haven't released anything) So maybe we should also add the command-line instructions for the time being?

* The page uses a table with a "Distribution" column, so I shoe-horned Flatpak into this as a "All distributions" option, but that doesn't really seem appropriate?