### PR TITLE
Remove the 'Installation on Linux' page

### DIFF
--- a/website/frontend/templates/docs/linux.html
+++ b/website/frontend/templates/docs/linux.html
@@ -27,46 +27,10 @@
         <pre>flatpak install flathub org.musicbrainz.Picard</pre>
       </span>
 
-      <h1 id="fedora">Fedora 7, 8 and Higher</h1>
-      <span>
-        <p>Picard is now in the official Fedora package collection: </p>
-        <p>
-          <a rel="nofollow" class="external free" href="https://admin.fedoraproject.org/pkgdb/packages/name/picard">
-            https://admin.fedoraproject.org/pkgdb/packages/name/picard
-          </a>
-        </p>
-        <p>
-          since dependent packages PyQt4 and libdiscid are now also available in Fedora. Just install with yum
-        </p>
-        <pre>yum install picard</pre>
-        <p>
-          Currently these packages do not have support for acoustic fingerprinting because that depends on
-          ffmpeg which isn't available in Fedora due to patent issues in ffmpeg.
-        </p>
-        <p>
-          ffmpeg is available from the livna rpm repository. It is necessary to install the packages ffmpeg
-          and ffmpeg-devel, and rebuild picard from the source RPM in order to enable PUID generation within
-          picard on Fedora.
-        </p>
-      </span>
-
-      <h1 id="mandriva">Mandriva</h1>
-      <span>
-        <p>
-          Picard is available in the Mandriva development version Cooker in the contribs repository. </p>
-        <p>
-          Cooker users can simply install it by running <pre>urpmi picard </pre>
-        </p>
-        <p>or by selecting it in rpmdrake. </p>
-      </span>
-    </div>
-
     <div class="col-md-4">
       <div id="sidebar" class="hidden-xs">
         <ul class="nav" data-spy="affix" data-offset-top="200">
           <li class="active"><a href="#flatpak">Flatpak</a></li>
-          <li><a href="#fedora">Fedora</a></li>
-          <li><a href="#mandriva">Mandriva</a></li>
         </ul>
         <!-- <a class="back-to-top" href="#top"> Back to top </a> -->
       </div>

--- a/website/frontend/templates/downloads.html
+++ b/website/frontend/templates/downloads.html
@@ -186,12 +186,6 @@
                       <a href="https://launchpad.net/~musicbrainz-developers/+archive/daily">MusicBrainz Daily PPA (Unstable)</a>
                     </td>
                   </tr>
-                  <tr>
-                    <td>{{ _("Others") }}</td>
-                    <td>
-                      <a href="{{ url_for('docs.show_pages', page='linux') }}">{{ _("Read the documentation") }}</a>
-                    </td>
-                  </tr>
                 </tbody>
               </table>
             </div>


### PR DESCRIPTION
Mandriva has been dead for a few years now and Fedora has packages for
picard in its standard repositories.