### PR TITLE
download_plugins: Use URLs for 1.0 if version is None

### DIFF
--- a/website/build_plugins.py
+++ b/website/build_plugins.py
@@ -24,7 +24,6 @@ PLUGIN_FILE_NAME = "plugins.json"
 PLUGIN_DIR = "plugins"
 
 VERSION_INFO = {
-    None: {'branch_name': 'master'},
     '1.0': {'branch_name': '1.0',
             'api_versions':  # Keep those ordered
             [
@@ -45,6 +44,8 @@ VERSION_INFO = {
             ]
             }
 }
+
+VERSION_INFO[None] = VERSION_INFO['1.0']
 
 KNOWN_DATA = [
     'PLUGIN_NAME',


### PR DESCRIPTION
Otherwise, the branch name used was master, which doesn't exist in the
repository anymore.

Without this, running the test cases always fail because `download_plugins` was downloading files from the no longer existing master branch on GitHub.