### PR TITLE
Only complain about missing API versions if it's really missing

### DIFF
--- a/website/frontend/errors.py
+++ b/website/frontend/errors.py
@@ -6,11 +6,14 @@ from flask import (
 )
 
 
+_API_ROOT_PATHS = ["/api", "/api/"]
+
+
 def init_error_handlers(app):
 
     @app.errorhandler(404)
     def not_found_handler(error):
-        if request.path.startswith("/api"):
+        if request.path in _API_ROOT_PATHS:
             return make_response(
                 jsonify({"message": "No API version specified"}), 404)
 

--- a/website/frontend/views/api_test.py
+++ b/website/frontend/views/api_test.py
@@ -21,11 +21,18 @@ class ViewsTestCase(FrontendTestCase):
         self.assert404(response)
 
     def test_api_root(self):
-        response = self.client.get("/api")
-        self.assert404(response)
-        self.assertEquals(response.json, dict(
-            message=_MESSAGES['missing_api_version']))
+        for path in ['/api', '/api/']:
+            response = self.client.get(path)
+            self.assert404(response)
+            self.assertEquals(response.json, dict(
+                message=_MESSAGES['missing_api_version']))
 
+    def test_api_noroute_path(self):
+        "Test API URLs with paths for which no route exists"
+        for path in ['/api/v1/:', '/api/v2/:', '/api/v3/:']:
+            response = self.client.get(path)
+            self.assert404(response)
+            self.assertTemplateUsed('errors/404.html')
     # /v1/
 
     def test_api_v1_redirect(self):


### PR DESCRIPTION
Otherwise, use the generic 404 page.