### PR TITLE
Update FAQ to link to new guide location

### DIFF
--- a/website/frontend/templates/docs/faq.html
+++ b/website/frontend/templates/docs/faq.html
@@ -10,7 +10,7 @@
       <h3 id="tag-files">How do I tag files with Picard?</h3>
       <p>
         There is a separate page that
-        <a href="/docs/guide/" title="How To Tag Files With Picard">explains the tagging process</a>.
+        <a href="/quick-start/" title="How to Tag Files With Picard">explains the tagging process</a>.
       </p>
 
       <h3 id="tagger-icon">


### PR DESCRIPTION
From #musicbrainz:
19:14 https://picard.musicbrainz.org/docs/faq/
19:14 the link at the beginning of this FAQ returns a 404 error
19:14 https://picard.musicbrainz.org/docs/guide/
19:15 looking at the Internet Archive copy, it looks like the page was moved here, which is identical: https://picard.musicbrainz.org/quick-start/
19:16 may need a redirect or at least to change the old links