### PR TITLE
Un-dockerignore docker/uwsgi.ini

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 
 # Docker configuration
 /docker
+!docker/uwsgi.ini
 
 # Byte-compiled / optimized / DLL files
 __pycache__/


### PR DESCRIPTION
It's COPYed by the Dockerfile, so it needs to be part of the build context.