### PR TITLE
Use HTTPS for linking to external links

### DIFF
--- a/website/frontend/templates/docs/build-osx.html
+++ b/website/frontend/templates/docs/build-osx.html
@@ -36,7 +36,7 @@
         </li>
         <li>
           Python 2.7.3. Since we want compatibility with Tiger/i386, make sure to install this one:
-          <a rel="nofollow" href="http://www.python.org/ftp/python/2.7.3/python-2.7.3-macosx10.3.dmg">
+          <a rel="nofollow" href="https://www.python.org/ftp/python/2.7.3/python-2.7.3-macosx10.3.dmg">
           python-2.7.3-macosx10.3.dmg</a>.
 
           Use the provided Update Shell Profile.command to make this your default Python. Note: this
@@ -66,7 +66,7 @@
 
       <p>
         Make sure you're using gcc 4.0.2. On Snow Leopard, I had to change the symlinks, because setting
-        CC= didn't work for some dependencies. (<a rel="nofollow" href="http://stackoverflow.com/questions/1165361/setting-gcc-4-2-as-the-default-compiler-on-mac-os-x-leopard">I did this</a>,
+        CC= didn't work for some dependencies. (<a rel="nofollow" href="https://stackoverflow.com/questions/1165361/setting-gcc-4-2-as-the-default-compiler-on-mac-os-x-leopard">I did this</a>,
         but for 4.0 instead of 4.2.)
       </p>
 

--- a/website/frontend/templates/docs/build-windows.html
+++ b/website/frontend/templates/docs/build-windows.html
@@ -38,7 +38,7 @@
       <ul>
         <li>
           Download and install Python 3 for Windows from
-          <a rel="nofollow" target="_blank" href="http://python.org/downloads/">http://python.org/downloads/</a>.
+          <a rel="nofollow" target="_blank" href="https://python.org/downloads/">https://python.org/downloads/</a>.
           The latest version is recommended, but if you already have Python 3 installed
           then the minimum version is 3.5.
         </li>
@@ -92,7 +92,7 @@ pip3 install Mutagen>=1.37</pre>
       <ul>
         <li>
           Download and install Python 2.7.x for Windows from
-          <a rel="nofollow" target="_blank" href="http://python.org/downloads/">http://python.org/downloads/</a>
+          <a rel="nofollow" target="_blank" href="https://python.org/downloads/">https://python.org/downloads/</a>
         </li>
         <li>
           Python should add itself to your %PATH% environment variable,
@@ -156,7 +156,7 @@ pip2 install discid</pre>
       <ul>
         <li>
           Download <a rel="nofollow" href="https://github.com/acoustid/chromaprint/releases/download/v1.4.2/chromaprint-fpcalc-1.4.2-windows-x86_64.zip">the x86_64 windows zip file</a>
-          from <a rel="nofollow" href="http://acoustid.org/chromaprint">http://acoustid.org/chromaprint</a>
+          from <a rel="nofollow" href="https://acoustid.org/chromaprint">https://acoustid.org/chromaprint</a>
         </li>
         <li>
           Unzip "chromaprint-fpcalc-1.1-win-i86.zip" and put "fpcalc.exe" to the picard subdirectory
@@ -206,7 +206,7 @@ pip2 install discid</pre>
           For Picard version 2 / Python 3.5+, download and install py2exe 0.9.2.0 by executing: "pip3 install py2exe"
         </li>
         <li>
-          For Picard version 1 / Python 2.7, download and install "py2exe-0.6.9.win32-py2.7.exe" from <a rel="nofollow" href="http://sourceforge.net/projects/py2exe/files/py2exe/0.6.9/">http://sourceforge.net/projects/py2exe/files/py2exe/0.6.9/</a>
+          For Picard version 1 / Python 2.7, download and install "py2exe-0.6.9.win32-py2.7.exe" from <a rel="nofollow" href="https://sourceforge.net/projects/py2exe/files/py2exe/0.6.9/">https://sourceforge.net/projects/py2exe/files/py2exe/0.6.9/</a>
         </li>
       </ul>
 
@@ -231,8 +231,8 @@ pip2 install discid</pre>
 
       <p>
         For Picard version 2 / Python 3,
-        download <a rel="nofollow" href="http://landinghub.visualstudio.com/visual-cpp-build-tools">Microsoft Visual C++ 14.0
-        standalone: Visual C++ Build Tools 2015 (x86, x64, ARM) from http://landinghub.visualstudio.com/visual-cpp-build-tools</a>.
+        download <a rel="nofollow" href="https://landinghub.visualstudio.com/visual-cpp-build-tools">Microsoft Visual C++ 14.0
+        standalone: Visual C++ Build Tools 2015 (x86, x64, ARM) from https://landinghub.visualstudio.com/visual-cpp-build-tools</a>.
       </p>
 
       <p>
@@ -243,7 +243,7 @@ pip2 install discid</pre>
 
       <p>
         For Picard version 1 / Python 2,
-        download <a rel="nofollow" href="http://download.microsoft.com/download/A/5/4/A54BADB6-9C3F-478D-8657-93B3FC9FE62D/vcsetup.exe">Visual C++ 2008 Express</a>.
+        download <a rel="nofollow" href="https://download.microsoft.com/download/A/5/4/A54BADB6-9C3F-478D-8657-93B3FC9FE62D/vcsetup.exe">Visual C++ 2008 Express</a>.
       </p>
 
       <p>

--- a/website/frontend/templates/docs/development.html
+++ b/website/frontend/templates/docs/development.html
@@ -58,12 +58,12 @@
 
       <p>
         For Mac there is <a href="/docs/build-osx/">Building Picard on OS X</a> and
-        also <a href="http://build.oxygene.sk/job/package-picard-osx-daily/" rel="nofollow">daily builds for OS X</a>.
+        also <a href="https://build.oxygene.sk/job/package-picard-osx-daily/" rel="nofollow">daily builds for OS X</a>.
       </p>
 
       <h1 id="License">License</h1>
       <p>
-        Picard is licensed under the <a href="http://www.gnu.org/copyleft/gpl.html" rel="nofollow">GPL 2.0 or later</a>.
+        Picard is licensed under the <a href="https://www.gnu.org/copyleft/gpl.html" rel="nofollow">GPL 2.0 or later</a>.
       </p>
     </div>
   </div>

--- a/website/frontend/templates/docs/faq.html
+++ b/website/frontend/templates/docs/faq.html
@@ -92,7 +92,7 @@
           <li> Ogg FLAC (.oggflac) </li>
           <li> Ogg Theora (.ogg) </li>
           <li> Ogg Opus (.opus) </li>
-          <li> Ogg Audio (.oga) </li> 
+          <li> Ogg Audio (.oga) </li>
           <li> Ogg Video (.ogv) </li>
         </ul>
       </p>
@@ -140,8 +140,8 @@
         To that end, Picard is likely to never have as much development focus on manual bulk editing of
         tags as other general purpose editors (e.g.
         <a href="https://musicbrainz.org/doc/Jaikoz" title="Jaikoz">Jaikoz</a>,
-        <a rel="nofollow" href="http://www.mp3tag.de/en/">Mp3tag</a>,
-        <a rel="nofollow"href="http://www.foobar2000.org/">foobar2000</a> or even many library managers
+        <a rel="nofollow" href="https://www.mp3tag.de/en/">Mp3tag</a>,
+        <a rel="nofollow"href="https://www.foobar2000.org/">foobar2000</a> or even many library managers
         such as iTunes, Windows Media Player, MediaMonkey). That doesn't mean that the team won't welcome
         patches in this area!
       </p>
@@ -168,14 +168,14 @@
         Acoustic fingerprinting in Picard uses a tool called
         <code>fpcalc</code>, which is not available in Fedora. You can get it by installing the
         <code>chromaprint-tools</code>package from the
-        <a rel="nofollow" class="external text" href="http://rpmfusion.org/">RPM Fusion</a> repository.
+        <a rel="nofollow" class="external text" href="https://rpmfusion.org/">RPM Fusion</a> repository.
 
         This functionality is not contained in the main Fedora <code>picard</code>package because it requires the
         <code>ffmpeg</code>package which
-        <a rel="nofollow" class="external text" href="http://fedoraproject.org/wiki/Forbidden_items">
+        <a rel="nofollow" class="external text" href="https://fedoraproject.org/wiki/Forbidden_items">
         cannot be distributed by Fedora</a>.
 
-        After <a rel="nofollow" class="external text" href="http://rpmfusion.org/Configuration">enabling</a> the
+        After <a rel="nofollow" class="external text" href="https://rpmfusion.org/Configuration">enabling</a> the
         "rpmfusion-free" RPM Fusion repository, install the package using (as root):
       </p>
       <pre>yum install chromaprint-tools</pre>

--- a/website/frontend/templates/docs/linux.html
+++ b/website/frontend/templates/docs/linux.html
@@ -15,7 +15,7 @@
       <span>
         <p>
           Picard is available on <a href="https://flathub.org">Flathub</a>. This version should work on all modern
-          Linux distributions, as long <a href="http://flatpak.org/getting.html">Flatpak is installed</a>.</p>
+          Linux distributions, as long <a href="https://flatpak.org/getting.html">Flatpak is installed</a>.</p>
         </p>
         <p>
           First enable the Flathub repository:

--- a/website/frontend/templates/docs/options.html
+++ b/website/frontend/templates/docs/options.html
@@ -174,8 +174,8 @@
         <li>
           <b>ID3v2 version:</b> Although id3v2.4 is the latest version, its support in music players
           is <b>still</b> lacking. Whilst software such as
-          <a rel="nofollow" class="external text" href="http://www.foobar2000.org">foobar2000</a> and
-          <a rel="nofollow" class="external text" href="http://www.mediamonkey.com">MediaMonkey</a>have
+          <a rel="nofollow" class="external text" href="https://www.foobar2000.org">foobar2000</a> and
+          <a rel="nofollow" class="external text" href="https://www.mediamonkey.com">MediaMonkey</a>have
           no problem using version 2.4 tags, you will not be able to read the tags in Windows Explorer
           or Windows Media Player (in any Windows or WMP version, including those in Windows 8.1).
           Apple iTunes is also still based in id3v23, and support for id3v24 in other media players
@@ -304,7 +304,7 @@
         <li> <b>Replace non-ASCII characters:</b> Check to replace non-ASCII characters with their ASCII equivalent,
           e.g. á,ä,ǎ, with a; é,ě,ë, with e; æ with ae, etc. For more information on ASCII characters
           read the Wikipedia page on
-          <a href="http://en.wikipedia.org/wiki/ASCII" class="extiw" title="wikipedia:ASCII">ASCII</a>.
+          <a href="https://en.wikipedia.org/wiki/ASCII" class="extiw" title="wikipedia:ASCII">ASCII</a>.
         </li>
         <li> <b>Replace Windows-incompatible characters:</b> Check to replace Windows-incompatible characters
           with an underscore. Enabled by default on Windows with no option to disable.


### PR DESCRIPTION
# Summary
* This is a…
    * [ ] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [x] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:
Update the link in the documentation from `HTTP` to `HTTPS`. Some of `HTTP` redirect to `HTTPS` but some of them not.

# Problem
* JIRA ticket (_optional_): No
* Follow up @samj1912 comment on https://github.com/metabrainz/picard-website/pull/103

# Solution
Just replace `HTTP` to `HTTPS` and tested before.
