### PR TITLE
Remove mention of picard_dev

### DIFF
--- a/website/frontend/templates/docs/development.html
+++ b/website/frontend/templates/docs/development.html
@@ -5,28 +5,6 @@
 <div id="docs" class="container">
   <div class="row">
     <div class="col-md-8">
-
-      <h1 id="dev_builds">Picard 2.0 Dev Builds</h1>
-      <p>
-      Picard 2.0 dev builds are now available via PyPi.
-      To install the dev builds you need to have a Python 3.5 or greater.
-      <br>
-      You can get the latest version of Python <a href="https://www.python.org/downloads/" rel="nofollow">here.</a>
-      </p>
-      <p>
-      Once you have Python 3.5 or greater installed, proceed to your commandline and install Picard via the following command -
-      <pre>pip3 install picard_dev</pre>
-
-      If all went well, you should now have Picard 2.0 available to you as
-      <pre>picard_dev</pre>
-      on your commandline.
-
-      Please note that Picard Dev version uses a different config file than your stable Picard installation. As such the settings and plugins will be on their default configuration.
-
-      To use your stable config with the dev version, simple copy your "Picard.ini" file from your MusicBrainz user folder to "Picard Dev.ini" which can be found in the same folder.
-
-      </p>
-      <h1 id="development">Development</h1>
       <p>
         The source code of Picard is maintained in Git and you can get it with all its history using:
         <pre>


### PR DESCRIPTION
# Summary

* This is a…
    * [ ] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [X] Minor / simple change (like a typo)
    * [ ] Other

# Problem

There hasn't been any maintenance after first publishing it. Pointing people to
old builds will likely do more harm than good.

# Solution

Remove the paragraph about picard_dev.

# Action

No additional action required.
