### PR TITLE
PW-62: Add current program release version info to api

### DIFF
--- a/website/default_config.py
+++ b/website/default_config.py
@@ -10,6 +10,11 @@ PLUGIN_VERSIONS = {
     'v1': '1.0',
     'v2': '2.0',
 }
+PICARD_VERSIONS = {
+    'stable': ('1.4.2', 'http://picard.musicbrainz.org/'),
+    'beta': ('2.0.0.beta1', 'https://github.com/metabrainz/picard/releases/tag/2.0.0.dev4'),
+    'dev': ('2.0.0.dev4', 'https://github.com/metabrainz/picard/releases/tag/2.0.0.dev4'),
+}
 CHANGELOG_URL = "https://raw.githubusercontent.com/musicbrainz/picard/master/NEWS.txt"
 CHANGELOG_CACHE_TIMEOUT = 5 * 60
 

--- a/website/frontend/views/api.py
+++ b/website/frontend/views/api.py
@@ -126,8 +126,10 @@ def get_versions(version):
     """
     Provides latest version numbers and download urls for the release paths
     """
+    ret_obj = {}
+    ret_obj['versions'] = picard_versions(current_app)
     if version and get_build_version(current_app, version):
         return make_response(
-            jsonify({'versions': picard_versions(current_app)), 200)
+            jsonify(ret_obj), 200)
     else:
         return invalid_api_version(404)

--- a/website/frontend/views/api.py
+++ b/website/frontend/views/api.py
@@ -71,6 +71,10 @@ def invalid_api_version(error):
     return make_response(jsonify({'error': 'Invalid API version'}), 404)
 
 
+def picard_versions(app):
+    return app.config['PICARD_VERSIONS']
+
+
 @api_bp.route('/<version>/', methods=['GET'])
 def api_root(version):
     """
@@ -113,5 +117,17 @@ def download_plugin(version):
             return make_response(
                 jsonify({'error': 'Plugin id not specified.',
                          'message': 'Correct usage: /api/%s/download?id=<id>' % version}), 400)
+    else:
+        return invalid_api_version(404)
+
+
+@api_bp.route('/<version>/releases/', methods=['GET'])
+def get_versions(version):
+    """
+    Provides latest version numbers and download urls for the release paths
+    """
+    if version and get_build_version(current_app, version):
+        return make_response(
+            jsonify({'versions': picard_versions(current_app), 200)
     else:
         return invalid_api_version(404)

--- a/website/frontend/views/api.py
+++ b/website/frontend/views/api.py
@@ -128,6 +128,6 @@ def get_versions(version):
     """
     if version and get_build_version(current_app, version):
         return make_response(
-            jsonify({'versions': picard_versions(current_app), 200)
+            jsonify({'versions': picard_versions(current_app)), 200)
     else:
         return invalid_api_version(404)


### PR DESCRIPTION
# Summary

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* Add latest version number and download url information for three release paths (i.e.: stable, beta, dev) to the api service.

# Problem

Current version information not readily available for update checking in Picard.

* JIRA ticket: [PW-62](https://tickets.metabrainz.org/browse/PW-62): Add latest program version information to api


# Solution

Current release version information is stored in the **default_config.py** file so that it is available to the api through flask.  The information is then served by the api in the form of a JSON response.

# Action

Please review the api changes closely because I've never worked with flask before.
