### PR TITLE
Use secure HTTPS download links

### DIFF
--- a/website/frontend/templates/downloads.html
+++ b/website/frontend/templates/downloads.html
@@ -34,7 +34,7 @@
                         <button type="button" class="btn btn-primary btn-sm dropdown-toggle" data-toggle="dropdown"> {{ _('Download') }} <span class="caret"></span>
                         </button>
                         <ul class="dropdown-menu" role="menu">
-                          <li><a href="ftp://ftp.musicbrainz.org/pub/musicbrainz/picard/picard-setup-2.0.1.exe">{{ _('US Mirror') }}</a></li>
+                          <li><a href="https://musicbrainz.osuosl.org/pub/musicbrainz/picard/picard-setup-2.0.1.exe">{{ _('US Mirror') }}</a></li>
                           <li><a href="ftp://ftp.eu.metabrainz.org/pub/musicbrainz/picard/picard-setup-2.0.1.exe">{{ _('EU Mirror') }}</a></li>
                         </ul>
                       </div>
@@ -75,7 +75,7 @@
                         <button type="button" class="btn btn-primary btn-sm dropdown-toggle" data-toggle="dropdown"> {{ _('Download') }} <span class="caret"></span>
                         </button>
                         <ul class="dropdown-menu" role="menu">
-                          <li><a href="ftp://ftp.musicbrainz.org/pub/musicbrainz/picard/picard-setup-1.4.2.exe">{{ _('US Mirror') }}</a></li>
+                          <li><a href="https://musicbrainz.osuosl.org/pub/musicbrainz/picard/picard-setup-1.4.2.exe">{{ _('US Mirror') }}</a></li>
                           <li><a href="ftp://ftp.eu.metabrainz.org/pub/musicbrainz/picard/picard-setup-1.4.2.exe">{{ _('EU Mirror') }}</a></li>
                         </ul>
                       </div>
@@ -116,7 +116,7 @@
                         <button type="button" class="btn btn-primary btn-sm dropdown-toggle" data-toggle="dropdown"> {{ _('Download') }} <span class="caret"></span>
                         </button>
                         <ul class="dropdown-menu" role="menu">
-                          <li><a href="ftp://ftp.musicbrainz.org/pub/musicbrainz/picard/MusicBrainz-Picard-2.0.1.dmg">{{ _('US Mirror') }}</a></li>
+                          <li><a href="https://musicbrainz.osuosl.org/pub/musicbrainz/picard/MusicBrainz-Picard-2.0.1.dmg">{{ _('US Mirror') }}</a></li>
                           <li><a href="ftp://ftp.eu.metabrainz.org/pub/musicbrainz/picard/MusicBrainz-Picard-2.0.1.dmg">{{ _('EU Mirror') }}</a></li>
                         </ul>
                       </div>
@@ -154,7 +154,7 @@
                         <button type="button" class="btn btn-primary btn-sm dropdown-toggle" data-toggle="dropdown"> {{ _('Download') }} <span class="caret"></span>
                         </button>
                         <ul class="dropdown-menu" role="menu">
-                          <li><a href="ftp://ftp.musicbrainz.org/pub/musicbrainz/picard/MusicBrainz-Picard-1.4.2.dmg">{{ _('US Mirror') }}</a></li>
+                          <li><a href="https://musicbrainz.osuosl.org/pub/musicbrainz/picard/MusicBrainz-Picard-1.4.2.dmg">{{ _('US Mirror') }}</a></li>
                           <li><a href="ftp://ftp.eu.metabrainz.org/pub/musicbrainz/picard/MusicBrainz-Picard-1.4.2.dmg">{{ _('EU Mirror') }}</a></li>
                         </ul>
                       </div>
@@ -192,7 +192,7 @@
                         <button type="button" class="btn btn-primary btn-sm dropdown-toggle" data-toggle="dropdown"> {{ _('Download') }} <span class="caret"></span>
                         </button>
                         <ul class="dropdown-menu" role="menu">
-                          <li><a href="ftp://ftp.musicbrainz.org/pub/musicbrainz/picard/MusicBrainz-Picard-1.2.dmg">{{ _('US Mirror') }}</a></li>
+                          <li><a href="https://musicbrainz.osuosl.org/pub/musicbrainz/picard/MusicBrainz-Picard-1.2.dmg">{{ _('US Mirror') }}</a></li>
                           <li><a href="ftp://ftp.eu.metabrainz.org/pub/musicbrainz/picard/MusicBrainz-Picard-1.2.dmg">{{ _('EU Mirror') }}</a></li>
                         </ul>
                       </div>
@@ -297,8 +297,8 @@
                         <button type="button" class="btn btn-primary btn-sm dropdown-toggle" data-toggle="dropdown"> {{ _('Download') }} <span class="caret"></span>
                         </button>
                         <ul class="dropdown-menu" role="menu">
-                          <li><a href="ftp://ftp.musicbrainz.org/pub/musicbrainz/picard/picard-2.0.1.tar.gz">{{ _('US Mirror (tar)') }}</a></li>
-                          <li><a href="ftp://ftp.musicbrainz.org/pub/musicbrainz/picard/picard-2.0.1.zip">{{ _('US Mirror (zip)') }}</a></li>
+                          <li><a href="https://musicbrainz.osuosl.org/pub/musicbrainz/picard/picard-2.0.1.tar.gz">{{ _('US Mirror (tar)') }}</a></li>
+                          <li><a href="https://musicbrainz.osuosl.org/pub/musicbrainz/picard/picard-2.0.1.zip">{{ _('US Mirror (zip)') }}</a></li>
                           <li><a href="ftp://ftp.eu.metabrainz.org/pub/musicbrainz/picard/picard-2.0.1.tar.gz">{{ _('EU Mirror (tar)') }}</a></li>
                           <li><a href="ftp://ftp.eu.metabrainz.org/pub/musicbrainz/picard/picard-2.0.1.zip">{{ _('EU Mirror (zip)') }}</a></li>
                         </ul>
@@ -312,7 +312,7 @@
           </li>
         </ul>
         {% autoescape false %}
-        <p>{{ _("This page lists the most recent downloads. If you're looking for older versions of Picard, {url|browse our FTP server}.")|expand({'url': 'http://ftp.musicbrainz.org/pub/musicbrainz/picard/?C=M;O=D'}) }}</p>
+        <p>{{ _("This page lists the most recent downloads. If you're looking for older versions of Picard, {url|browse our FTP server}.")|expand({'url': 'https://musicbrainz.osuosl.org/pub/musicbrainz/picard/?C=M;O=D'}) }}</p>
         {% endautoescape %}
 {% endblock %}
     </div><!-- /.container -->

--- a/website/frontend/templates/index.html
+++ b/website/frontend/templates/index.html
@@ -107,7 +107,7 @@
       var platform = navigator.platform, downloadURL, iconClass, infoText;
 
       if (/^Win/.test(platform) || /Windows/.test(navigator.userAgent)) {
-        downloadURL = "http://ftp.musicbrainz.org/pub/musicbrainz/picard/picard-setup-2.0.1.exe";
+        downloadURL = "https://musicbrainz.osuosl.org/pub/musicbrainz/picard/picard-setup-2.0.1.exe";
         iconClass = "fa-windows";
         infoText = "v2.0.1 for Windows (64-bit)";
 
@@ -117,7 +117,7 @@
         infoText = "v2.0.1 for Linux Distributions";
 
       } else if (platform === "MacIntel" || platform === "MacPPC") {
-        downloadURL = "ftp://ftp.musicbrainz.org/pub/musicbrainz/picard/MusicBrainz-Picard-2.0.1.dmg";
+        downloadURL = "https://musicbrainz.osuosl.org/pub/musicbrainz/picard/MusicBrainz-Picard-2.0.1.dmg";
         iconClass = "fa-apple";
         infoText = "v2.0.1 for OS X 10.10+";
       }


### PR DESCRIPTION
# Summary

* This is a…
    * [ ] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [x] Other
* **Describe this change in 1-2 sentences**:

# Problem

Current download links use insecure HTTP links.

# Solution

This PR upgrades the links to HTTPS.
Unfortunately I didn't find a HTTPS url for the EU mirror.