### PR TITLE
PW-62: Add latest program version information to api

### DIFF
--- a/website/config.py.example
+++ b/website/config.py.example
@@ -4,6 +4,36 @@
 #    'v2': '2.0',
 #    'v1': '1.0',
 #}
+#
+## PICARD_VERSIONS dictionary valid keys are: 'stable', 'beta' and 'dev'.
+## The 'version' tuple comprises int_major, int_minor, int_micro, str_type and int_development as defined in PEP-440.
+## The Picard developers have standardized on using only 'dev' or 'final' as the str_type segment of the version tuple.
+#PICARD_VERSIONS = {
+#    'stable': {
+#        'tag': '2.0.1',
+#        'version': ( 2, 0, 1, 'final', 0),
+#        'urls': {
+#            'download': 'https://picard.musicbrainz.org/',
+#            'changelog': 'https://picard.musicbrainz.org/changelog/',
+#        }
+#    },
+#    'beta': {
+#        'tag': '2.0.0.beta3',
+#        'version': ( 2, 0, 0, 'dev', 6),
+#        'urls': {
+#            'download': 'https://github.com/metabrainz/picard/releases/tag/2.0.0dev6',
+#            'changelog': 'https://github.com/metabrainz/picard/compare/2.0.0dev6...master',
+#        }
+#    },
+#    'dev': {
+#        'tag': '2.0.2.dev1',
+#        'version': ( 2, 0, 2, 'dev', 1),
+#        'urls': {
+#            'download': 'https://github.com/metabrainz/picard',
+#        }
+#    },
+#}
+#
 #CHANGELOG_URL = "https://raw.githubusercontent.com/musicbrainz/picard/master/NEWS.txt"
 #CHANGELOG_CACHE_TIMEOUT = 5 * 60
 #

--- a/website/default_config.py
+++ b/website/default_config.py
@@ -10,6 +10,36 @@ PLUGIN_VERSIONS = {
     'v1': '1.0',
     'v2': '2.0',
 }
+
+ # PICARD_VERSIONS dictionary valid keys are: 'stable', 'beta' and 'dev'.
+ # The 'version' tuple comprises int_major, int_minor, int_micro, str_type and int_development as defined in PEP-440.
+ # The Picard developers have standardized on using only 'dev' or 'final' as the str_type segment of the version tuple.
+PICARD_VERSIONS = {
+    'stable': {
+        'tag': '2.0.1',
+        'version': ( 2, 0, 1, 'final', 0),
+        'urls': {
+            'download': 'https://picard.musicbrainz.org/',
+            'changelog': 'https://picard.musicbrainz.org/changelog/',
+        }
+    },
+    'beta': {
+        'tag': '2.0.0.beta3',
+        'version': ( 2, 0, 0, 'dev', 6),
+        'urls': {
+            'download': 'https://github.com/metabrainz/picard/releases/tag/2.0.0dev6',
+            'changelog': 'https://github.com/metabrainz/picard/compare/2.0.0dev6...master',
+        }
+    },
+    'dev': {
+        'tag': '2.0.2.dev1',
+        'version': ( 2, 0, 2, 'dev', 1),
+        'urls': {
+            'download': 'https://github.com/metabrainz/picard',
+        }
+    },
+}
+
 CHANGELOG_URL = "https://raw.githubusercontent.com/musicbrainz/picard/master/NEWS.txt"
 CHANGELOG_CACHE_TIMEOUT = 5 * 60
 

--- a/website/default_config.py
+++ b/website/default_config.py
@@ -16,8 +16,8 @@ PLUGIN_VERSIONS = {
 # The Picard developers have standardized on using only 'dev' or 'final' as the str_type segment of the version tuple.
 PICARD_VERSIONS = {
     'stable': {
-        'tag': '2.0.1',
-        'version': ( 2, 0, 1, 'final', 0),
+        'tag': '2.0.2',
+        'version': ( 2, 0, 2, 'final', 0),
         'urls': {
             'download': 'https://picard.musicbrainz.org/',
             'changelog': 'https://picard.musicbrainz.org/changelog/',
@@ -32,8 +32,8 @@ PICARD_VERSIONS = {
         }
     },
     'dev': {
-        'tag': '2.0.2.dev1',
-        'version': ( 2, 0, 2, 'dev', 1),
+        'tag': '2.0.3.dev1',
+        'version': ( 2, 0, 3, 'dev', 1),
         'urls': {
             'download': 'https://github.com/metabrainz/picard',
         }

--- a/website/default_config.py
+++ b/website/default_config.py
@@ -11,9 +11,9 @@ PLUGIN_VERSIONS = {
     'v2': '2.0',
 }
 
- # PICARD_VERSIONS dictionary valid keys are: 'stable', 'beta' and 'dev'.
- # The 'version' tuple comprises int_major, int_minor, int_micro, str_type and int_development as defined in PEP-440.
- # The Picard developers have standardized on using only 'dev' or 'final' as the str_type segment of the version tuple.
+# PICARD_VERSIONS dictionary valid keys are: 'stable', 'beta' and 'dev'.
+# The 'version' tuple comprises int_major, int_minor, int_micro, str_type and int_development as defined in PEP-440.
+# The Picard developers have standardized on using only 'dev' or 'final' as the str_type segment of the version tuple.
 PICARD_VERSIONS = {
     'stable': {
         'tag': '2.0.1',

--- a/website/frontend/views/api.py
+++ b/website/frontend/views/api.py
@@ -125,7 +125,52 @@ def download_plugin(version):
 @api_bp.route('/<version>/releases/', methods=['GET'])
 def get_versions(version):
     """
-    Provides latest version numbers and download urls for the release paths
+    Provides latest version numbers and download urls for the release paths.
+
+    One intended use for the new PW versions api endpoint is to provide the current
+    available release information to Picard for automatic update checking (PICARD-1045).
+    The proposed update checking flow within Picard would generally be:
+
+      1. Check new configuration setting to determine the update level to process. The
+         levels proposed are: 1 = Stable releases only; 2 = Stable and Beta releases;
+         3 = Stable, Beta and Dev releases.
+
+      2. Query the new PW api endpoint to get the latest available version information.
+         The intent is that this would only occur once per Picard session, and the
+         information would be stored in a temporary session variable in a new
+         UpdateCheckManager class in case multiple (manual) update checks are performed
+         during the session. The date of the latest successful call to the endpoint
+         would be stored in a new persistent variable.
+
+      3. Compare the version tuples for each of the update levels in the user's
+         "subscription" (from Step 1) to determine the highest available version within
+         the subscribed levels.
+
+      4. Compare the highest available version from Step 3 to the currently running
+         version of Picard. If a new version is available, open a dialog box informing
+         the user, showing the current version and the available version number (tag),
+         and provide an option to open the download url. If no update was available, and
+         the update check was initiated manually, a dialog box would be displayed to
+         inform the user that no update was available (based on their selected update
+         level).
+
+      5. Upon Picard start-up, a new configuration setting would be checked to determine
+         whether automatic update checking is enabled. If enabled, the current date would
+         be compared to the date of the last successful check (from the persistent
+         variable stored during Step 2) to see whether or not it is within the number of
+         days between automatic checks specified in another new configuration setting. If
+         it's within the interval, no check is performed. If beyond the interval, a check
+         would be performed but there will be no dialog box notification unless a newer
+         version is available.
+
+      6. There would be a new option on the Help portion of the main toolbar to allow the
+         user to manually initiate an update check.
+
+    In summary, it is proposed to add three new configuration settings to Picard:
+    1) update level to check; 2) automatic update checking enabled; and 3) minimum
+    interval (in days) between automatic update checks. It is also proposed to add one
+    new persistent variable: date of last update check, one new start-up action:
+    automatic update check, and one new toolbar action: manually check for updates.
     """
     ret_obj = {}
     ret_obj['versions'] = picard_versions(current_app)

--- a/website/frontend/views/api.py
+++ b/website/frontend/views/api.py
@@ -71,6 +71,10 @@ def invalid_api_version(error):
     return make_response(jsonify({'error': 'Invalid API version'}), 404)
 
 
+def picard_versions(app):
+    return app.config['PICARD_VERSIONS']
+
+
 @api_bp.route('/<version>/', methods=['GET'])
 def api_root(version):
     """
@@ -78,8 +82,9 @@ def api_root(version):
     """
     if version and get_build_version(current_app, version):
         return make_response(
-            jsonify({'message': 'The two endpoints currently available for this api version'
-                     ' are /api/%s/plugins and /api/%s/download' % (version, version)}), 200)
+            jsonify({'message': 'The endpoints currently available for this api version'
+                     ' are /api/%s/plugins, /api/%s/download and /api/%s/releases' %
+                     (version, version, version)}), 200)
     else:
         return invalid_api_version(404)
 
@@ -113,5 +118,19 @@ def download_plugin(version):
             return make_response(
                 jsonify({'error': 'Plugin id not specified.',
                          'message': 'Correct usage: /api/%s/download?id=<id>' % version}), 400)
+    else:
+        return invalid_api_version(404)
+
+
+@api_bp.route('/<version>/releases/', methods=['GET'])
+def get_versions(version):
+    """
+    Provides latest version numbers and download urls for the release paths
+    """
+    ret_obj = {}
+    ret_obj['versions'] = picard_versions(current_app)
+    if version and get_build_version(current_app, version):
+        return make_response(
+            jsonify(ret_obj), 200)
     else:
         return invalid_api_version(404)

--- a/website/frontend/views/api.py
+++ b/website/frontend/views/api.py
@@ -83,8 +83,8 @@ def api_root(version):
     if version and get_build_version(current_app, version):
         return make_response(
             jsonify({'message': 'The endpoints currently available for this api version'
-                     ' are /api/%s/plugins, /api/%s/download and /api/%s/releases' %
-                     (version, version, version)}), 200)
+                     ' are /api/%s/plugins, /api/%s/download and /api/releases' %
+                     (version, version)}), 200)
     else:
         return invalid_api_version(404)
 
@@ -122,8 +122,8 @@ def download_plugin(version):
         return invalid_api_version(404)
 
 
-@api_bp.route('/<version>/releases/', methods=['GET'])
-def get_versions(version):
+@api_bp.route('/releases/', methods=['GET'])
+def get_versions():
     """
     Provides latest version numbers and download urls for the release paths.
 
@@ -172,10 +172,5 @@ def get_versions(version):
     new persistent variable: date of last update check, one new start-up action:
     automatic update check, and one new toolbar action: manually check for updates.
     """
-    ret_obj = {}
-    ret_obj['versions'] = picard_versions(current_app)
-    if version and get_build_version(current_app, version):
-        return make_response(
-            jsonify(ret_obj), 200)
-    else:
-        return invalid_api_version(404)
+    ret_obj = {'versions': picard_versions(current_app)}
+    return make_response(jsonify(ret_obj), 200)

--- a/website/frontend/views/api_test.py
+++ b/website/frontend/views/api_test.py
@@ -5,8 +5,8 @@ from flask import url_for
 _MESSAGES = {
     'plugin_not_found': 'Plugin not found.',
     'missing_api_version': 'No API version specified',
-    'invalid_endpoint': 'The two endpoints currently available for this api version'
-                        ' are /api/v1/plugins and /api/v1/download',
+    'invalid_endpoint': 'The endpoints currently available for this api version'
+                        ' are /api/v1/plugins, /api/v1/download and /api/v1/releases',
     'missing_id': 'Plugin id not specified.',
     'download_usage': 'Correct usage: /api/v1/download?id=<id>',
 }


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard Website. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [picard/CONTRIBUTING.md](https://github.com/metabrainz/picard-website/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**: This change provides an api end point returning information about the current versions of Picard for three update paths (i.e.: stable, beta and dev).  The information includes the version tag, version tuple, and a download link.

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->
Update the api to provide latest version numbers and download urls for three release paths: stable, beta and dev.  This can then be used by Picard for determining whether an update is available.

* JIRA ticket (_optional_): [PW-62](https://tickets.metabrainz.org/browse/PW-62) Add latest program version information to api
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
The version information for the three update paths is stored in the ***website/default_config.py*** file.  This is provided in response to a new api call to endpoint "versions".  This will provide the currently available version information for automatic update checking in Picard (see [PICARD-1045](https://tickets.metabrainz.org/browse/PICARD-1045)).

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
Please review and confirm the structure of the information returned for the three update paths, so that this can be incorporated into [Picard PR# 904](https://github.com/metabrainz/picard/pull/904).
