### PR TITLE
Add syntax highlighting for function examples

### DIFF
--- a/website/frontend/templates/docs/scripting.html
+++ b/website/frontend/templates/docs/scripting.html
@@ -202,7 +202,7 @@
             multi-valued tag. This can be used to operate on multi-valued tags as a string, and then set
             them back as proper multi-valued tags, e.g</li>
           <li class="example">
-            <pre>$setmulti(genre,$lower(%genre%))</pre>
+            <pre><code class="taggerscript">$setmulti(genre,$lower(%genre%))</code></pre>
           </li>
           <li class="added">Since Picard 1.0</li>
         </ul>
@@ -537,7 +537,7 @@
             'A' and 'The' are used by default.
           </li>
           <li class="example">
-            <pre>$swapprefix(%albumartist%,A,An,The,Le)</pre>
+            <pre><code class="taggerscript">$swapprefix(%albumartist%,A,An,The,Le)</code></pre>
           </li>
           <li class="added">Integrated since Picard 1.3, previously as a plugin since Picard 0.13</li>
         </ul>


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard Website. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [picard/CONTRIBUTING.md](https://github.com/metabrainz/picard-website/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

Some example scripts used in function documentation had no syntax highlighting applied



# Solution

Added syntax highlighting

# Action

There is another small example at the bottom of https://picard.musicbrainz.org/docs/tags/ . But I think that is not worth adding the highlight.js script to this page.