### PR TITLE
Default to plugin API v2 in plugin list

### DIFF
--- a/website/frontend/templates/plugins.html
+++ b/website/frontend/templates/plugins.html
@@ -7,13 +7,13 @@
         {% autoescape false %}
         <p>
             {{ _("This is a list of plugins that are currently available for use with Picard.") }}
-            {{ _("The current production release of Picard v1.4.x uses API v1. The development version of Picard v2.0dev uses API v2.") }}
+            {{ _("The current production release of Picard 2.x uses API v2. The older Picard 1.x releases use API v1.") }}
             {{ _("The table is generated from the data of our plugin {urlrepo|repository}.")|expand({"urlrepo": "https://github.com/musicbrainz/picard-plugins"}) }}
         </p>
         {% endautoescape %}
         <ul class="nav nav-tabs">
         {% for version in all_plugins.keys() %}
-          <li {% if version == '1' %} class="active" {% endif %}>
+          <li {% if version == '2' %} class="active" {% endif %}>
             <a data-toggle="tab" href="#apiv{{version}}">API v{{version}}</a>
           </li>
         {% endfor %}


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard Website. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [picard/CONTRIBUTING.md](https://github.com/metabrainz/picard-website/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem
The current plugin page defaults to API v1 and has an outdated description at the top.



# Solution
Default to API v2 and show current release version as Picard 2.x
# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

