### PR TITLE
Move 'releases' endpoint to api/v2

### DIFF
--- a/website/frontend/views/api.py
+++ b/website/frontend/views/api.py
@@ -81,10 +81,15 @@ def api_root(version):
     Shows info about our API
     """
     if version and get_build_version(current_app, version):
-        return make_response(
-            jsonify({'message': 'The endpoints currently available for this api version'
-                     ' are /api/%s/plugins, /api/%s/download and /api/releases' %
-                     (version, version)}), 200)
+        if version == 'v2':
+            msg_text = 'The endpoints currently available for this api version' \
+                ' are /api/{ver}/plugins, /api/{ver}/download and /api/{ver}/releases'.format(
+                    ver=version)
+        else:
+            msg_text = 'The endpoints currently available for this api version' \
+                ' are /api/{ver}/plugins and /api/{ver}/download'.format(
+                    ver=version)
+        return make_response(jsonify({'message': msg_text}), 200)
     else:
         return invalid_api_version(404)
 
@@ -122,7 +127,7 @@ def download_plugin(version):
         return invalid_api_version(404)
 
 
-@api_bp.route('/releases/', methods=['GET'])
+@api_bp.route('/v2/releases/', methods=['GET'])
 def get_versions():
     """
     Provides latest version numbers and download urls for the release paths.

--- a/website/frontend/views/api_test.py
+++ b/website/frontend/views/api_test.py
@@ -6,7 +6,7 @@ _MESSAGES = {
     'plugin_not_found': 'Plugin not found.',
     'missing_api_version': 'No API version specified',
     'invalid_endpoint': 'The endpoints currently available for this api version'
-                        ' are /api/v1/plugins, /api/v1/download and /api/releases',
+                        ' are /api/v1/plugins and /api/v1/download',
     'missing_id': 'Plugin id not specified.',
     'download_usage': 'Correct usage: /api/v1/download?id=<id>',
 }
@@ -100,12 +100,12 @@ class ViewsTestCase(FrontendTestCase):
         self.assert200(response)
         self.assertEquals(response.content_type, 'application/zip')
 
-    # /v1/releases
+    # /v2/releases
 
-    def test_api_v1_releases(self):
-        "Test /api/releases"
+    def test_api_v2_releases(self):
+        "Test /api/v2/releases"
         url_re = re.compile(r'^(ftp|https?)://[^\s"]+$', re.IGNORECASE)
-        response = self.client.get("/api/releases/")
+        response = self.client.get("/api/v2/releases/")
         self.assert200(response)
         updates = response.json['versions']
         self.assertIsInstance(updates, dict)


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard Website. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [picard/CONTRIBUTING.md](https://github.com/metabrainz/picard-website/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [x] Other
* **Describe this change in 1-2 sentences**:  Move the `releases` api endpoint to `api/v2/releases` as discussed in [Picard PR #914](https://github.com/metabrainz/picard/pull/904).

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PW-XXX](https://tickets.metabrainz.org/browse/PW-XXX)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Currently the `releases` api endpoint is not associated with an api version.

# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
Move the  `releases` api endpoint to the `v2` api version.

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->
None.
