### PR TITLE
Picard 2.1.0

### DIFF
--- a/website/frontend/templates/docs/mappings.html
+++ b/website/frontend/templates/docs/mappings.html
@@ -114,6 +114,9 @@
           </td>
           <td>
             <code>TXXX:Work</code>
+            <br />
+            <code>TIT1</code> <sup id="cite_ref-7"
+              class="reference"><a href="#cite_note-7">[8]</a></sup>
           </td>
           <td>
             <code>WORK</code>
@@ -662,6 +665,9 @@
           </td>
           <td>
             <code>TIT1</code>
+            <br />
+            <code>GRP1</code> <sup id="cite_ref-7"
+              class="reference"><a href="#cite_note-7">[8]</a></sup>
           </td>
           <td>
             <code>GROUPING</code>
@@ -1768,6 +1774,12 @@
         </span>
         <span class="reference-text"><a href="https://musicbrainz.org/relationship/f25e301d-b87b-4561-86a0-5d2df6d26c0a" class="extiw"
           title="rt:f25e301d-b87b-4561-86a0-5d2df6d26c0a">Recording-level license relationship type</a>
+        </span>
+      </li>
+      <li id="cite_note-7">
+        <span class="mw-cite-backlink"><a href="#cite_ref-7">↑</a>
+        </span>
+        <span class="reference-text">With "Save iTunes compatible grouping and work" (since Picard&gt;=2.1.0)</a>
         </span>
       </li>
     </ol>

--- a/website/frontend/templates/docs/mappings.html
+++ b/website/frontend/templates/docs/mappings.html
@@ -1450,8 +1450,10 @@
           <td>
           </td>
           <td>
+            <code>----:com.apple.iTunes:MusicBrainz Original Album Id</code> <i>(Picard&gt;=2.1)</i>
           </td>
           <td>
+            <code>MusicBrainz/Original Album Id</code> <i>(Picard&gt;=2.1)</i>
           </td>
         </tr>
         <tr>
@@ -1491,8 +1493,10 @@
           <td>
           </td>
           <td>
+            <code>----:com.apple.iTunes:MusicBrainz Original Artist Id</code> <i>(Picard&gt;=2.1)</i>
           </td>
           <td>
+            <code>MusicBrainz/Original Artist Id</code> <i>(Picard&gt;=2.1)</i>
           </td>
         </tr>
         <tr>

--- a/website/frontend/templates/docs/mappings.html
+++ b/website/frontend/templates/docs/mappings.html
@@ -283,6 +283,7 @@
           <td>
           </td>
           <td>
+            <code>WM/OriginalAlbumTitle</code>  <i>(Picard&gt;=2.1)</i>
           </td>
         </tr>
         <tr>
@@ -296,10 +297,12 @@
           <td>
           </td>
           <td>
+            <code>Original Artist</code>  <i>(Picard&gt;=2.1)</i>
           </td>
           <td>
           </td>
           <td>
+            <code>WM/OriginalArtist</code>  <i>(Picard&gt;=2.1)</i>
           </td>
         </tr>
         <tr>

--- a/website/frontend/templates/docs/mappings.html
+++ b/website/frontend/templates/docs/mappings.html
@@ -113,7 +113,7 @@
             <code>work</code>
           </td>
           <td>
-            <code>TXXX:Work</code>
+            <code>TXXX:WORK</code>
             <br />
             <code>TIT1</code> <sup id="cite_ref-7"
               class="reference"><a href="#cite_note-7">[8]</a></sup>
@@ -125,6 +125,7 @@
             <code>WORK</code>
           </td>
           <td>
+            <code>&copy;wrk</code>  <i>(Picard&gt;=2.1)</i>
           </td>
           <td>
             <code>WM/Work</code>

--- a/website/frontend/templates/docs/mappings.html
+++ b/website/frontend/templates/docs/mappings.html
@@ -946,7 +946,7 @@
           </td>
         </tr>
         <tr>
-          <th> <a href="https://musicbrainz.org/doc/Folksonomy_Tagging" title="Folksonomy Tagging">Genre</a>
+          <th> <a href="https://musicbrainz.org/doc/Genre" title="Genre">Genre</a>
           </th>
           <td>
             <code>genre</code>

--- a/website/frontend/templates/docs/mappings.html
+++ b/website/frontend/templates/docs/mappings.html
@@ -662,6 +662,81 @@
           </td>
         </tr>
         <tr>
+          <th>Movement<sup id="cite_ref-notinstockpicard_3-0" class="reference"><a href="#cite_note-notinstockpicard-3">[4]</a></sup> (Picard&gt;=2.1)
+          </th>
+          <td>
+            <code>movement</code>
+          </td>
+          <td>
+            <code>MVNM</code>
+          </td>
+          <td>
+          </td>
+          <td>
+          </td>
+          <td>
+            <code>©mvn</code>
+          </td>
+          <td>
+          </td>
+        </tr>
+        <tr>
+          <th>Movement Number<sup id="cite_ref-notinstockpicard_3-0" class="reference"><a href="#cite_note-notinstockpicard-3">[4]</a></sup> (Picard&gt;=2.1)
+          </th>
+          <td>
+            <code>movementnumber</code>
+          </td>
+          <td>
+            <code>MVIN</code>
+          </td>
+          <td>
+          </td>
+          <td>
+          </td>
+          <td>
+            <code>mvi</code>
+          </td>
+          <td>
+          </td>
+        </tr>
+        <tr>
+          <th>Movement Count<sup id="cite_ref-notinstockpicard_3-0" class="reference"><a href="#cite_note-notinstockpicard-3">[4]</a></sup> (Picard&gt;=2.1)
+          </th>
+          <td>
+            <code>movementtotal</code>
+          </td>
+          <td>
+            <code>MVIN</code>
+          </td>
+          <td>
+          </td>
+          <td>
+          </td>
+          <td>
+            <code>mvc</code>
+          </td>
+          <td>
+          </td>
+        </tr>
+        <tr>
+          <th>Show Work &amp; Movement<sup id="cite_ref-notinstockpicard_3-0" class="reference"><a href="#cite_note-notinstockpicard-3">[4]</a></sup> (Picard&gt;=2.1)
+          </th>
+          <td>
+            <code>showmovement</code>
+          </td>
+          <td>
+          </td>
+          <td>
+          </td>
+          <td>
+          </td>
+          <td>
+            <code>shwm</code>
+          </td>
+          <td>
+          </td>
+        </tr>
+        <tr>
           <th>Grouping<sup id="cite_ref-lastfmplugin_2-0" class="reference"><a href="#cite_note-lastfmplugin-2">[3]</a></sup>
           </th>
           <td>

--- a/website/frontend/templates/docs/mappings.html
+++ b/website/frontend/templates/docs/mappings.html
@@ -671,8 +671,10 @@
             <code>MVNM</code>
           </td>
           <td>
+            <code>MOVEMENTNAME</code>
           </td>
           <td>
+            <code>MOVEMENTNAME</code>
           </td>
           <td>
             <code>©mvn</code>
@@ -690,8 +692,10 @@
             <code>MVIN</code>
           </td>
           <td>
+            <code>MOVEMENT</code>
           </td>
           <td>
+            <code>MOVEMENT</code>
           </td>
           <td>
             <code>mvi</code>
@@ -709,8 +713,10 @@
             <code>MVIN</code>
           </td>
           <td>
+            <code>MOVEMENTTOTAL</code>
           </td>
           <td>
+            <code>MOVEMENTTOTAL</code>
           </td>
           <td>
             <code>mvc</code>
@@ -725,10 +731,13 @@
             <code>showmovement</code>
           </td>
           <td>
+            <code>TXXX:SHOWMOVEMENT</code>
           </td>
           <td>
+            <code>SHOWMOVEMENT</code>
           </td>
           <td>
+            <code>SHOWMOVEMENT</code>
           </td>
           <td>
             <code>shwm</code>

--- a/website/frontend/templates/docs/options.html
+++ b/website/frontend/templates/docs/options.html
@@ -29,6 +29,34 @@
           want Picard to do this scan automatically. In any case, you can direct Picard to scan a particular
           music file at any time using the <i>Scan</i> button in the toolbar.
         </li>
+        <li>
+          <b>Check for updates during start-up:</b> Check this box if you want Picard to check for program updates
+          automatically. Leave it unchecked if you don't want Picard to do this check automatically. In any case, you
+          can have Picard check for program updates at any time using the <i>Help</i> --&gt; <i>Check for update</i>
+          command in the drop-down menu.
+        </li>
+        <li>
+          <b>Days between checks:</b> This option allows you to limit the automatic update checking by selecting
+          the interval, in days, between checks. Set this to <i>1</i> if you want to check daily, <i>7</i> for weekly
+          checks, and so on. Note that this only applies if the <i>Check for updates during start-up</i> option is
+          selected.
+        </li>
+        <li>
+          <b>Updates to check:</b> This option allows you to select which levels of update to check. Your options are:
+          <ul>
+            <li>
+              Stable releases only
+            </li>
+            <li>
+              Stable and Beta releases
+            </li>
+            <li>
+              Stable, Beta and Dev releases
+            </li>
+          </ul>
+          For example, if you subscribe to <i>Stable releases only</i> you will not be notified if a new Beta or Dev
+          release is issued.
+        </li>
       </ul>
 
       <h1 id="metadata">Metadata</h1>

--- a/website/frontend/templates/docs/options.html
+++ b/website/frontend/templates/docs/options.html
@@ -104,10 +104,6 @@
           <b>Use track relationships:</b> Check to write track-level relationships to your files, e.g. composer,
           lyricist, performer, remixer, etc.
         </li>
-        <li>
-          <b>Use folksonomy tags as genres:</b> Check to write MusicBrainz folksonomy tags as genres. (See
-          options under "Folksonomy Tags")
-        </li>
         <li><b>Various artists:</b> Choose how you want the 'Various Artists' artist spelled.</li>
         <li>
           <b>Non-album tracks:</b> Choose how you want 'non-album tracks'
@@ -135,24 +131,30 @@
         </li>
       </ul>
 
-      <h3 id="folksonomy_tags">Folksonomy tags</h3>
+      <h3 id="genres">Genres</h3>
 
-      <p>The following settings are only applicable if you enable the <i>use folksonomy tags as genres</i> option.
-      </p>
       <ul class="options">
-        <li> <b>Ignore tags:</b> Comma-separated list of tags to ignore when writing genres.
+        <li>
+          <b>Use genres from MusicBrainz:</b> Use <a href="https://musicbrainz.org/doc/Genre" title="Genres">genres</a>
+          provided by MusicBrainz and save them to the <code>genre</code> tag.
         </li>
-        <li> <b>Only use my tags:</b> Check to only write genres with tags that you personally have submitted
+        <li> <b>Only use my genres:</b> Check to only write genres you personally have submitted
           to MusicBrainz. You'll need to set your username and password to use this feature.
         </li>
-        <li> <b>Minimal tag usage:</b> Choose how popular the tag must be before it is written by Picard. Default:
-          90%. Lowering the value here will lead to more tags in your files, but possibly less relevant
-          tags.
+        <li>
+          <b>Use folksonomy tags as genres:</b> Check to use all
+          <a href="https://musicbrainz.org/doc/Folksonomy_Tagging" title="Folksonomy Tagging">folksonomy tags</a>
+          to set the genre. Otherwise only the tags considered by MusicBrainz to be proper genres will be used.
         </li>
-        <li> <b>Maximum number of tags:</b> Choose how many tags to write as genres. Default: 5. If you only
+        <li> <b>Genres or folksonomy tags to exclude:</b> Comma-separated list of genres or tags to ignore when writing genres.
+        </li>
+        <li> <b>Minimal genre usage:</b> Choose how popular the genre must be before it is written by Picard. Default:
+          90%. Lowering the value here will lead to more, but possibly less relevant, genres in your files.
+        </li>
+        <li> <b>Maximum number of genres:</b> Choose how many genres to use. Default: 5. If you only
           want a single genre, set this to 1.
         </li>
-        <li> <b>Join multiple tags with:</b> Select which character should be used to separate multiple tags.
+        <li> <b>Join multiple genres with:</b> Select which character should be used to separate multiple genres.
         </li>
       </ul>
 
@@ -575,7 +577,7 @@
             <a href="#metadata">Metadata</a>
             <ul class="nav">
               <li><a href="#preferred_releases">Preferred Releases</a></li>
-              <li><a href="#folksonomy_tags">Folksonomy tags</a></li>
+              <li><a href="#genres">Genres</a></li>
               <li><a href="#ratings">Ratings</a></li>
             </ul>
           </li>

--- a/website/frontend/templates/docs/options.html
+++ b/website/frontend/templates/docs/options.html
@@ -58,6 +58,11 @@
           release is issued.
         </li>
       </ul>
+      <p>
+        <em>Note: The update settings and "Check for update" function may not be available when Picard is distributed
+        as a package.  In that case, the user should check with the maintainer of the package to determine when an
+        update is available.</em>
+      </p>
 
       <h1 id="metadata">Metadata</h1>
 

--- a/website/frontend/templates/docs/options.html
+++ b/website/frontend/templates/docs/options.html
@@ -195,6 +195,14 @@
           in Picard between id3v23 and other tagging formats.
         </li>
         <li>
+          <b>Save iTunes compatible grouping and work:</b> Save the tags <code>grouping</code> and
+          <code>work</code> so that they are compatible with current iTunes versions. Without this option
+          <code>grouping</code> will be displayed in iTunes as "work name" and <code>work</code> will not be
+          available. See the <a href="/docs/mappings" title="Picard Tag Mapping">Picard Tag Mapping</a> for
+          details.<br>
+          <em>Note: For other players supporting grouping and work you might need to disable this option. MusicBee is one example for this.</em>
+        </li>
+        <li>
           <b>Also include ID3v1 tags in the files:</b> Not recommended at all. ID3v1.1 tags are obsolete
           and may not work with non-latin scripts.
         </li>

--- a/website/frontend/templates/docs/options.html
+++ b/website/frontend/templates/docs/options.html
@@ -330,6 +330,13 @@
       <p>Most music players will display only one piece of cover art for the album, and most people select
         Front (cover) for that.
       </p>
+      <p>When selecting the cover art image types, you can select both the types to include and exclude from
+        the download list.  CAA images with an image type found in the '<i>Include</i>' list will be downloaded
+        and used unless they also have an image type found in the '<i>Exclude</i>' list. Images with types found
+        in the '<i>Exclude</i>' list will <b>never</b> be used. Image types not appearing in the '<i>Include</i>'
+        or '<i>Exclude</i>' lists will not be considered when determining whether or not to download and use a
+        CAA image.
+      </p>
       <p>Since Picard 1.3, you can also decide to use the image from the release group (if any) if no front
         image is found for the release. In this case, the cover may not match the exact release you are
         tagging (eg. a 1979 vinyl front cover may be used in place of the Deluxe 2010 CD reissue).

--- a/website/frontend/templates/docs/options.html
+++ b/website/frontend/templates/docs/options.html
@@ -52,6 +52,11 @@
           if a suitable alias is found.
         </li>
         <li>
+          <b>Use standardized instrument and vocal credits:</b> Check to only use standard names for
+          instruments and vocals in performer relationships. Uncheck to use the instruments / vocals as
+          credited in the relationship.
+        </li>
+        <li>
           <b>Convert Unicode punctuation characters to ASCII:</b> Converts Unicode punctuation characters
           in MusicBrainz data to ASCII for consistent use of punctuation in tags. For example, right
           single quotation marks (’) are converted to ASCII apostrophes ('), and horizontal ellipses

--- a/website/frontend/templates/docs/options.html
+++ b/website/frontend/templates/docs/options.html
@@ -236,7 +236,21 @@
           The mask should <b>not</b> contain a file extension; this is added automatically based on the
           actual image type. The default value is
           <code>cover</code>. If you change this to
-          <code>folder</code>, Windows will use it to preview the containing folder.
+          <code>folder</code>, Windows will use it to preview the containing folder.<br />
+          In addition to scripting variables already available for a track you can use the following
+          cover art specific variables:
+          <ul>
+            <li>
+              <code>coverart_maintype</code>: The primary type (e.g. front, medium, booklet etc.). For front
+              images this will always be "front".
+            </li>
+            <li>
+              <code>coverart_types</code>: Full list of all types assigned to this image.
+            </li>
+            <li>
+              <code>coverart_comment</code>: The cover art comment.
+            </li>
+          </ul>
         </li>
         <li>
           <b>Overwrite the file if it already exists:</b> Check this to replace existing files. This is

--- a/website/frontend/templates/docs/scripting.html
+++ b/website/frontend/templates/docs/scripting.html
@@ -168,17 +168,6 @@
           <li class="added">Since Picard 1.0</li>
         </ul>
 
-        <h3 id="unset_name">$unset(name)</h3>
-
-        <ul>
-          <li>Unsets the variable
-            <code>name</code>.
-          </li>
-          <li>Allows for wildcards to unset certain tags (works with 'performer:*', 'comment:*', and 'lyrics:*').
-            <br>i.e. <code>$unset(performer:*)</code> would unset all performer tags.
-          </li>
-        </ul>
-
         <h3 id="set_name_value">$set(name,value)</h3>
 
         <ul>
@@ -205,6 +194,30 @@
             <pre><code class="taggerscript">$setmulti(genre,$lower(%genre%))</code></pre>
           </li>
           <li class="added">Since Picard 1.0</li>
+        </ul>
+
+        <h3 id="unset_name">$unset(name)</h3>
+
+        <ul>
+          <li>Unsets the variable
+            <code>name</code>.
+          </li>
+          <li>Allows for wildcards to unset certain tags (works with 'performer:*', 'comment:*', and 'lyrics:*').
+            <br>i.e. <code>$unset(performer:*)</code> would unset all performer tags.
+          </li>
+        </ul>
+
+        <h3 id="delete_name">$delete(name)</h3>
+
+        <ul>
+          <li>Unsets the variable <code>name</code> and marks the tag for deletion.
+          </li>
+          <li>
+            This is similar to <code>$unset(name)</code> but also marks the tag for deletion.
+            E.g. running <code>$delete(genre)</code> will actually remove the genre tag from a file
+            when saving.
+          </li>
+          <li class="added">Since Picard 2.1</li>
         </ul>
 
         <h3 id="get_name">$get(name)</h3>

--- a/website/frontend/templates/docs/scripting.html
+++ b/website/frontend/templates/docs/scripting.html
@@ -722,6 +722,27 @@ $if(%date%,$left(%date%,4)) - $left(%album%,40) \(%releasestatus%-%releasetype%\
 $left(%album%,30) \(%releasestatus%-%releasetype%\)-$if($gt(%totaldiscs%,1),$if2(%media%,CD)%discnumber%-,)$num(%tracknumber%,2)-$left(%title%,30)
 
 )</code></pre>
+
+      <h1 id="coverart_naming_examples">Cover Art Naming Examples</h1>
+
+      <p>
+        <b><i>Options</i> &#8594; <i>Options...</i> &#8594; <i>Cover Art</i></b>
+      </p>
+      <p>
+        Tagger Script can be used to change the file names of saved cover art images.
+      </p>
+
+      <h3 id="album_title_as_cover_name">Use album title for cover art file names</h3>
+
+      <pre><code class="taggerscript">%album%</code></pre>
+
+      <h3 id="different_front_and_main_type">Use main type for images that are not front images</h3>
+
+      <p>
+        This will name front images "AlbumArt" and all other images according to their maintype (e.g. "medium" or "booklet").
+      </p>
+
+      <pre><code class="taggerscript">$if($eq(%coverart_maintype%,front),AlbumArt,%coverart_maintype%)</code></pre>
     </div>
 
     <div class="col-md-4">
@@ -752,6 +773,12 @@ $left(%album%,30) \(%releasestatus%-%releasetype%\)-$if($gt(%totaldiscs%,1),$if2
               <li><a href="#organize_by_alphabetical_folders_excluding_leading_the">Organize by alphabetical folders</a></li>
             </ul>
           </li>
+          <li>
+            <a href="#coverart_naming_examples">Cover Art Naming Examples</a>
+            <ul class="nav">
+              <li><a href="#album_title_as_cover_name">Use album title for cover art file names</a>
+              <li><a href="#different_front_and_main_type">Use main type for images that are not front images</a>
+            </ul>
         </ul>
       </div>
     </div>

--- a/website/frontend/templates/docs/scripting.html
+++ b/website/frontend/templates/docs/scripting.html
@@ -503,6 +503,15 @@
           <li class="added">Since Picard 0.10</li>
         </ul>
 
+        <h3 id="title_text">$title(text)</h3>
+
+        <ul>
+          <li>Returns <code>text</code> in title case (first character in every
+            word capitalized).
+          </li>
+          <li class="added">Since Picard 2.1</li>
+        </ul>
+
         <h3 id="firstalphachar_text_nonalpha">$firstalphachar(text,nonalpha="#")</h3>
 
         <ul>

--- a/website/frontend/templates/docs/tags.html
+++ b/website/frontend/templates/docs/tags.html
@@ -512,11 +512,13 @@
         </tr>
       </table>
 
-      <p>And if you enable folksonomy tags, you get:</p>
+      <p>If you enable <a href="/docs/options/#genres">Use genres from MusicBrainz</a>, you get:</p>
       <table class="table table-bordered table-striped">
         <tr>
           <td>genre</td>
-          <td>Pseudo-genre based on folksonomy tags</td>
+          <td><a href="https://musicbrainz.org/doc/Genre" title="Genre">Genre information from MusicBrainz</a>
+            (since Picard 2.1, earlier versions used
+            <a href="https://musicbrainz.org/doc/Folksonomy_Tagging" title="folksonomy tags">folksonomy tags</a>)</td>
         </tr>
       </table>
 

--- a/website/frontend/templates/docs/tags.html
+++ b/website/frontend/templates/docs/tags.html
@@ -541,6 +541,58 @@
         </tr>
       </table>
 
+      <h1 id="classical_variables">Tags for Classical Music</h1>
+
+      <p>
+        With the help of plugins like "Classical Extras" or "Work &amp; Movement"
+        you can make use of the following tags for tagging your classical music.
+      </p>
+
+      <table class="table table-bordered table-striped">
+        <tr>
+          <td>work</td>
+          <td>
+            <a href="https://musicbrainz.org/doc/Work#Name" title="Work">Work Name</a> of
+            the overall work, e.g. "Symphony no. 5 in C minor, op. 67".
+          </td>
+        </tr>
+        <tr>
+          <td>movement</td>
+          <td>
+            Name of the movement, e.g. "Andante con moto".
+          </td>
+        </tr>
+        <tr>
+          <td>movementnumber</td>
+          <td>
+            Movement number in Arabic numerals, e.g. "2". Players explicitly supporting this
+            tag will often display it in Roman numerals, in this example as "II".
+          </td>
+        </tr>
+        <tr>
+          <td>movementtotal</td>
+          <td>
+            Total number of movements in the work, e.g. "4".
+          </td>
+        </tr>
+        <tr>
+          <td>showmovement</td>
+          <td>
+            Show Work &amp; Movement: If this tag is set to "1" players supporting this
+            tag, like iTunes and MusicBee, will display the work, movement number and
+            movement name instead of the track title. E.g. the track will be displayed
+            as "Symphony no. 5 in C minor, op. 67: II. Andante con moto" regardless of
+            the value of the <code>title</code> tag.
+          </td>
+        </tr>
+      </table>
+
+      <p>
+        <em>Note: If you are using iTunes together with MP3 files you should activate
+        the option <a href="/docs/options/#tag_compatibility" title="Tag Compatibility Options">Save iTunes compatible grouping and work</a>
+        in order for the work to be displayed correctly.</em>
+      </p>
+
       <h1 id="plugins">Plugins</h1>
 
       <p>
@@ -660,6 +712,7 @@
           <li><a href="#basic_variables">Basic Variables</a></li>
           <li><a href="#advanced_tags">Advanced Tags</a></li>
           <li><a href="#advanced_variables">Advanced Variables</a></li>
+          <li><a href="#classical_variables">Tags for Classical Music</a></li>
           <li>
           <a href="#plugins">Plugins</a>
             <ul class="nav">

--- a/website/frontend/templates/docs/tags.html
+++ b/website/frontend/templates/docs/tags.html
@@ -445,24 +445,31 @@
         </tr>
         <tr>
           <td>performer:&lt;type&gt;</td>
-          <td>Performer Relationship Type (<a href="https://musicbrainz.org/relationship/888a2320-52e4-4fe8-a8a0-7a4c8dfde167"
-            class="extiw" title="rt:888a2320-52e4-4fe8-a8a0-7a4c8dfde167">releases</a> - <a href="https://musicbrainz.org/relationship/eb10f8a0-0f4c-4dce-aa47-87bcb2bc42f3"
-            class="extiw" title="rt:eb10f8a0-0f4c-4dce-aa47-87bcb2bc42f3">vocals</a>/<a href="https://musicbrainz.org/relationship/67555849-61e5-455b-96e3-29733f0115f5"
-            class="extiw" title="rt:67555849-61e5-455b-96e3-29733f0115f5">instruments</a>, <a href="https://musicbrainz.org/relationship/628a9658-f54c-4142-b0c0-95f031b544da"
-            class="extiw" title="rt:628a9658-f54c-4142-b0c0-95f031b544da">recordings</a> - <a href="https://musicbrainz.org/relationship/0fdbe3c6-7700-4a31-ae54-b53f06ae1cfa"
-            class="extiw" title="rt:0fdbe3c6-7700-4a31-ae54-b53f06ae1cfa">vocals</a>/<a href="https://musicbrainz.org/relationship/59054b12-01ac-43ee-a618-285fd397e461"
-            class="extiw" title="rt:59054b12-01ac-43ee-a618-285fd397e461">instruments</a>),
+          <td>
+            <p>Performer Relationship Type (<a href="https://musicbrainz.org/relationship/888a2320-52e4-4fe8-a8a0-7a4c8dfde167"
+              class="extiw" title="rt:888a2320-52e4-4fe8-a8a0-7a4c8dfde167">releases</a> - <a href="https://musicbrainz.org/relationship/eb10f8a0-0f4c-4dce-aa47-87bcb2bc42f3"
+              class="extiw" title="rt:eb10f8a0-0f4c-4dce-aa47-87bcb2bc42f3">vocals</a>/<a href="https://musicbrainz.org/relationship/67555849-61e5-455b-96e3-29733f0115f5"
+              class="extiw" title="rt:67555849-61e5-455b-96e3-29733f0115f5">instruments</a>, <a href="https://musicbrainz.org/relationship/628a9658-f54c-4142-b0c0-95f031b544da"
+              class="extiw" title="rt:628a9658-f54c-4142-b0c0-95f031b544da">recordings</a> - <a href="https://musicbrainz.org/relationship/0fdbe3c6-7700-4a31-ae54-b53f06ae1cfa"
+              class="extiw" title="rt:0fdbe3c6-7700-4a31-ae54-b53f06ae1cfa">vocals</a>/<a href="https://musicbrainz.org/relationship/59054b12-01ac-43ee-a618-285fd397e461"
+              class="extiw" title="rt:59054b12-01ac-43ee-a618-285fd397e461">instruments</a>), &lt;type&gt; can
+              be "vocal", "guest guitar", "solo violin", …
+            </p>
             <p>Orchestra Relationship Type (<a href="https://musicbrainz.org/relationship/23a2e2e7-81ca-4865-8d05-2243848a77bf"
               class="extiw" title="rt:23a2e2e7-81ca-4865-8d05-2243848a77bf">releases</a>, <a href="https://musicbrainz.org/relationship/3b6616c5-88ba-4341-b4ee-81ce1e6d7ebb"
-              class="extiw" title="rt:3b6616c5-88ba-4341-b4ee-81ce1e6d7ebb">recordings</a>), &lt;type&gt; can
-              be "orchestra", "vocal", "guest guitar", ...
-            </p></td>
+              class="extiw" title="rt:3b6616c5-88ba-4341-b4ee-81ce1e6d7ebb">recordings</a>), &lt;type&gt; is "orchestra"
+            </p>
+            <p>Concertmaster Relationship Type (<a href="https://musicbrainz.org/relationship/8a2b1c46-0fe5-42f7-9d72-f68604244c1d"
+              class="extiw" title="rt:8a2b1c46-0fe5-42f7-9d72-f68604244c1d">releases</a>, <a href="https://musicbrainz.org/relationship/ffeaa74f-8295-45ee-a2f2-7c0cc1f73b1e"
+              class="extiw" title="rt:ffeaa74f-8295-45ee-a2f2-7c0cc1f73b1e">recordings</a>), &lt;type&gt; is "concertmaster"
+            </p>
+          </td>
         </tr>
         <tr>
           <td>arranger</td>
           <td> Arranger Relationship Type (<a href="https://musicbrainz.org/relationship/34d5334e-a4c8-4b65-a5f8-bbcc9c81d13d" class="extiw" title="rt:34d5334e-a4c8-4b65-a5f8-bbcc9c81d13d">releases</a>, <a href="https://musicbrainz.org/relationship/22661fb8-cdb7-4f67-8385-b2a8be6c9f0d"
             class="extiw" title="rt:22661fb8-cdb7-4f67-8385-b2a8be6c9f0d">recordings</a>, <a href="https://musicbrainz.org/relationship/d3fd781c-5894-47e2-8c12-86cc0e2c8d08"
-            class="extiw" title="rt:d3fd781c-5894-47e2-8c12-86cc0e2c8d08">works</a>), 
+            class="extiw" title="rt:d3fd781c-5894-47e2-8c12-86cc0e2c8d08">works</a>),
             <p><a href="#"
               class="new" title="Instrumentator Relationship Type (page does not exist)">Instrumentator Relationship Type</a>,
               <a href="#"


### PR DESCRIPTION
This pull request contains all changes needed for the upcoming Picard 2.1.0. If you want to propose a documentation change needed for new or changed functionality in Picard 2.1.0 please open a pull request to merge into the `picard-2.1.0` branch.

List of required documentation changes:

- [x] https://github.com/metabrainz/picard/pull/928: Add an option to save grouping and work compatible with iTunes
- [x] https://github.com/metabrainz/picard/pull/927: Provide cover art metadata in cover art naming script
- [x] https://github.com/metabrainz/picard/pull/962: Load concertmaster as performer:concertmaster
- [x] https://github.com/metabrainz/picard/pull/970: Add `$delete` function
- [x] https://github.com/metabrainz/picard/pull/978: Allow using instruments and vocals as credited
- [x] https://github.com/metabrainz/picard/pull/914: Add information regarding CAA image type selection
- [x] https://github.com/metabrainz/picard/pull/904: Add information regarding program update checking
- [ ] https://github.com/metabrainz/picard/pull/974: Add a command-line option (-P) to force Picard ignoring all plugins
- [x] https://github.com/metabrainz/picard/pull/1018: Document `$title` function
- [x] https://github.com/metabrainz/picard/pull/1030: Document work tag for MP4 as `©wrk`
- [x] https://github.com/metabrainz/picard/pull/1029: Document iTunes compatible movement tags
- [x] https://github.com/metabrainz/picard/pull/1036: Document movement tags for Vorbis and APE
- [x] https://github.com/metabrainz/picard/pull/926: Document `originalalbum` / `originalartist` mapping
- [x] https://github.com/metabrainz/picard/pull/1043: Document updated ID3 mapping for `work` and `artists`
- [x] https://github.com/metabrainz/picard/pull/1024: Add note the update check might not be available for distribution packages
- [x] https://github.com/metabrainz/picard/pull/1046: Document `musicbrainz_originalalbumid` / `musicbrainz_originalartistid` mapping to ASF and MP4
- [x] https://github.com/metabrainz/picard/pull/1047: Update documentation for MusicBrainz genres (options and tags page)