### PR TITLE
Fixed escaping in changelog rendering

### DIFF
--- a/website/frontend/templates/changelog.html
+++ b/website/frontend/templates/changelog.html
@@ -6,25 +6,17 @@
       <div id="log">
       {% for line in lines %}
         {% if line is re_search("^Version\s+(.*?)\s+-\s+(.*?)") %}
-          <h3>Version
+          <h3 id="release-{{ line | version(1) }}">Version
             <strong>{{ line | version(1) }}</strong>
             <span>{{ line | version(2) | re_sub("xxxx\-xx\-xx", "Yet to be released.")}}</span>
           </h3>
         {% else %}
-          {% if line is re_search("(PICARD\-\d+)") %}
-            {% set data = line | re_sub("(PICARD\-\d+)", '<a href="https://tickets.musicbrainz.org/browse/\g<1>">\g<1></a>') | safe %}
-          {% elif line is re_search("#(\d+)") %}
-            {% set data = line | re_sub("#(\d+)", '<a href="http://bugs.musicbrainz.org/ticket/\g<1>">#\g<1></a>') | safe %}
-          {% else %}
-            {% set data = line %}
-          {% endif %}
-
           {% if line is re_search("\s+?\*\s+") %}
-            <p class="newLine">{{ data | re_sub("\s+?\*\s+", "")}}</p>
+            <p class="newLine">{{ line | re_sub("\s+?\*\s+", "") | add_markup }}</p>
           {% elif line is re_search("\s*\*\*\s+") %}
-            <h4>{{ data | re_sub("\s*\*\*\s+", "")}}</h4>
+            <h4>{{ line | re_sub("\s*\*\*\s+", "")}}</h4>
           {% else %}
-            <p>{{ data }}</p>
+            <p>{{ line | add_markup }}</p>
           {% endif %}
         {% endif %}
       {% endfor %}


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard Website. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [picard/CONTRIBUTING.md](https://github.com/metabrainz/picard-website/blob/master/CONTRIBUTING.md).
-->

# Summary

Fix escaping of hrefs in changelog rendering.

Also:
- Cleaned up code and moved part of logic to Python file
- Add link anchors for versions ( so we can link to e.g. `/changelog/#release-2.1.1`)
- Markup \`...\` as `&lt;code&gt;...&lt;/code&gt;`

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PW-XXX](https://tickets.metabrainz.org/browse/PW-XXX)
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

