### PR TITLE
Fix move files documentation

### DIFF
--- a/website/frontend/templates/docs/options.html
+++ b/website/frontend/templates/docs/options.html
@@ -471,10 +471,10 @@ comment</pre>
         <li> <b>Replace Windows-incompatible characters:</b> Check to replace Windows-incompatible characters
           with an underscore. Enabled by default on Windows with no option to disable.
         </li>
-        <li> <b>Move files to this directory when saving:</b> Choose a destination parent directory to move
+        <li> <b>Move files when saving:</b> Choose a destination parent directory to move
           saved files to.
           <ul class="options">
-            <li>If you use the directory "," they will be removed relative to their current location. If
+            <li>If you use the directory "." they will be moved relative to their current location. If
               they are already in some sort of folder structure, this will probably <i>not</i> do what
               you want!
             </li>


### PR DESCRIPTION
Fix the title of the "Move files when saving" option to match what the
app says, and fix a typo where "," was used instead of "." to refer to
the current directory.