### PR TITLE
PICARD-2181: Allow Markdown for plugin descriptions

### DIFF
--- a/website/build_plugins.py
+++ b/website/build_plugins.py
@@ -3,6 +3,7 @@
 import ast
 import os
 import json
+import mistune
 import re
 import shutil
 import zipfile
@@ -60,6 +61,7 @@ KNOWN_DATA = [
 ]
 
 _version_re = re.compile(r"(\d+)[._](\d+)(?:[._](\d+)[._]?(?:(dev|final)[._]?(\d+))?)?$")
+markdown = mistune.Markdown()
 
 
 class VersionError(Exception):
@@ -98,7 +100,10 @@ def get_plugin_data(filepath):
                     name = target.id.replace('PLUGIN_', '', 1).lower()
                     if name not in data:
                         try:
-                            data[name] = ast.literal_eval(node.value)
+                            value = ast.literal_eval(node.value)
+                            if name == 'description':
+                                value = markdown(value)
+                            data[name] = value
                         except ValueError:
                             print('Cannot evaluate value in '
                                   + filepath + ':' +


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard Website. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [picard/CONTRIBUTING.md](https://github.com/metabrainz/picard-website/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PICARD-2181
* https://github.com/metabrainz/picard/pull/1787

<!--
    Please make sure you prefix your pull request title with 'PW-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Many plugins try to come with a more comprehensive description, including some markup. So far those plugins contained HTML tags. Allowing markdown will allow easier and better readable (in source) formatting.

# Solution
Add Markdown parsing for plugins, using the already used mistune library.

An example how this can simplify the plugin description:

https://github.com/phw/picard-plugins/blob/opencc/plugins/opencc/__init__.py#L25

vs.

https://github.com/phw/picard-plugins/blob/9abfa27e4f2a407a2fe5d36fd5d64df37369c542/plugins/opencc/__init__.py#L25

That's a simple example, and part of better readability comes of course from the change to triple quote string. But we have more complex plugins.

It renders like this:

![grafik](https://user-images.githubusercontent.com/29852/114270740-574fcf80-9a0e-11eb-945f-8217cbf7a754.png)

As HTML is allowed in markdown existing descriptions continue to render properly. Likewise pure markdown still remains readable without conversion to HTML.



<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action
I will submit a likewise patch for Picard.

For the listing of downloadable plugins even older Picard versions would render the description fine as the description is served by the website after conversion to HTML. We could change that, but I would keep it that way for compatibility for a while.

We should not immediately start converting plugin descriptions to Markdown, though. Older Picard versions would not render the description of installed plugins properly. Instead we should use Markdown only for plugins compatible with Picard API version 2.7 or later. This change is here to start transitioning.
<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

