### PR TITLE
Replace mistune by markdown for plugin description rendering

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ Flask-Testing == 0.7.1
 Flask==1.1.1
 itsdangerous==1.1.0
 Jinja2==2.11.3
+markdown==3.3.4
 MarkupSafe==1.1.1
 mistune==0.8.4
 pytest-cov==2.8.1

--- a/website/build_plugins.py
+++ b/website/build_plugins.py
@@ -3,7 +3,7 @@
 import ast
 import os
 import json
-import mistune
+from markdown import markdown
 import re
 import shutil
 import zipfile
@@ -66,7 +66,6 @@ KNOWN_DATA = [
 ]
 
 _version_re = re.compile(r"(\d+)[._](\d+)(?:[._](\d+)[._]?(?:(dev|final)[._]?(\d+))?)?$")
-markdown = mistune.Markdown()
 
 
 class VersionError(Exception):


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard Website. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [picard/CONTRIBUTING.md](https://github.com/metabrainz/picard-website/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

Fixes issues with mistune not handling some HTML, e.g. `<ul>`, properly. E.g. this is not rendered correctly:

```
'''Add's the following tags:
<ul>
<li>Key (in ID3v2.3 format)</li>
<li>Beats Per Minute (BPM)</li>
</ul>
from the AcousticBrainz database.<br/><br/>
'''
```

It results in wrong:

    "<p>Add's the following tags:</p>\n<p><ul></p>\n<p><li>Key (in ID3v2.3 format)</li></p>\n<p><li>Beats Per Minute (BPM)</li>\n&lt;/ul&gt;\nfrom the AcousticBrainz database.<br/><br/></p>\n"


# Solution

Use markdown package instead of mistune.

Still use mistune for changelog renderning, though. I thought about replacing it, but customizing mistune for special rendering of headlines is much easier than for markdown. It would be possible, but requires a bit more coding, see https://python-markdown.github.io/extensions/api/

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->


# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

