### PR TITLE
PW-105: Remove US mirror links

### DIFF
--- a/website/config.py.example
+++ b/website/config.py.example
@@ -45,6 +45,7 @@
 #
 #DOCS_BASE_URL = "https://picard-docs.musicbrainz.org"
 #CHANGELOG_URL = "https://raw.githubusercontent.com/musicbrainz/picard/master/NEWS.md"
+#FILESERVER_URL = "https://data.musicbrainz.org/pub/musicbrainz/picard"
 #CHANGELOG_CACHE_TIMEOUT = 5 * 60
 #
 #SUPPORTED_LANGUAGES = [

--- a/website/default_config.py
+++ b/website/default_config.py
@@ -75,6 +75,7 @@ PICARD_VERSIONS = {
 
 DOCS_BASE_URL = "https://picard-docs.musicbrainz.org"
 CHANGELOG_URL = "https://raw.githubusercontent.com/musicbrainz/picard/master/NEWS.md"
+FILESERVER_URL = "https://data.musicbrainz.org/pub/musicbrainz/picard"
 CHANGELOG_CACHE_TIMEOUT = 5 * 60
 
 SUPPORTED_LANGUAGES = [

--- a/website/frontend/templates/downloads.html
+++ b/website/frontend/templates/downloads.html
@@ -32,16 +32,9 @@
                     <td class="hidden-xs hidden-sm">{{stable.win_hash}}</td>
                     <td>{{stable.win_size}} MB</td>
                     <td>
-                      <div class="btn-group">
-                        <button type="button" class="btn btn-primary btn-sm dropdown-toggle" data-toggle="dropdown">
-                          <i class="fa fa-download"></i>&emsp;{{ _('Download') }}
-                          <span class="caret"></span>
-                        </button>
-                        <ul class="dropdown-menu" role="menu">
-                          <li><a href="https://musicbrainz.osuosl.org/pub/musicbrainz/picard/picard-setup-{{stable.tag}}.exe">{{ _('US Mirror') }}</a></li>
-                          <li><a href="https://data.musicbrainz.org/pub/musicbrainz/picard/picard-setup-{{stable.tag}}.exe">{{ _('EU Mirror') }}</a></li>
-                        </ul>
-                      </div>
+                      <a class="btn btn-primary btn-sm" href="https://data.musicbrainz.org/pub/musicbrainz/picard/picard-setup-{{stable.tag}}.exe">
+                        <i class="fa fa-windows"></i>&emsp;{{ _('Download') }}
+                      </a>
                     </td>
                   </tr>
                   <tr>
@@ -49,20 +42,9 @@
                     <td class="hidden-xs hidden-sm">{{stable.win_portable_hash}}</td>
                     <td>{{stable.win_portable_size}} MB</td>
                     <td>
-                      <div class="btn-group">
-                        <button type="button" class="btn btn-primary btn-sm dropdown-toggle" data-toggle="dropdown">
-                          <i class="fa fa-download"></i>&emsp;{{ _('Download') }}
-                          <span class="caret"></span>
-                        </button>
-                        <ul class="dropdown-menu" role="menu">
-                          <li><a
-                              href="https://musicbrainz.osuosl.org/pub/musicbrainz/picard/MusicBrainz-Picard-{{stable.tag}}.exe">{{ _('US Mirror') }}</a>
-                          </li>
-                          <li><a
-                              href="https://data.musicbrainz.org/pub/musicbrainz/picard/MusicBrainz-Picard-{{stable.tag}}.exe">{{ _('EU Mirror') }}</a>
-                          </li>
-                        </ul>
-                      </div>
+                      <a class="btn btn-primary btn-sm" href="https://data.musicbrainz.org/pub/musicbrainz/picard/MusicBrainz-Picard-{{stable.tag}}.exe">
+                        <i class="fa fa-windows"></i>&emsp;{{ _('Download') }}
+                      </a>
                     </td>
                   </tr>
                   <tr>
@@ -85,20 +67,9 @@
                     <td class="hidden-xs hidden-sm">{{beta.win_hash}}</td>
                     <td>{{beta.win_size}} MB</td>
                     <td>
-                      <div class="btn-group">
-                        <button type="button" class="btn btn-primary btn-sm dropdown-toggle" data-toggle="dropdown">
-                          <i class="fa fa-download"></i>&emsp;{{ _('Download') }}
-                          <span class="caret"></span>
-                        </button>
-                        <ul class="dropdown-menu" role="menu">
-                          <li><a
-                              href="https://musicbrainz.osuosl.org/pub/musicbrainz/picard/picard-setup-{{beta.tag}}.exe">{{ _('US Mirror') }}</a>
-                          </li>
-                          <li><a
-                              href="https://data.musicbrainz.org/pub/musicbrainz/picard/picard-setup-{{beta.tag}}.exe">{{ _('EU Mirror') }}</a>
-                          </li>
-                        </ul>
-                      </div>
+                      <a class="btn btn-primary btn-sm" href="https://data.musicbrainz.org/pub/musicbrainz/picard/picard-setup-{{beta.tag}}.exe">
+                        <i class=" fa fa-windows"></i>&emsp;{{ _('Download') }}
+                      </a>
                     </td>
                   </tr>
                   <tr>
@@ -106,20 +77,9 @@
                     <td class="hidden-xs hidden-sm">{{beta.win_portable_hash}}</td>
                     <td>{{beta.win_portable_size}} MB</td>
                     <td>
-                      <div class="btn-group">
-                        <button type="button" class="btn btn-primary btn-sm dropdown-toggle" data-toggle="dropdown">
-                          <i class="fa fa-download"></i>&emsp;{{ _('Download') }}
-                          <span class="caret"></span>
-                        </button>
-                        <ul class="dropdown-menu" role="menu">
-                          <li><a
-                              href="https://musicbrainz.osuosl.org/pub/musicbrainz/picard/MusicBrainz-Picard-{{beta.tag}}.exe">{{ _('US Mirror') }}</a>
-                          </li>
-                          <li><a
-                              href="https://data.musicbrainz.org/pub/musicbrainz/picard/MusicBrainz-Picard-{{beta.tag}}.exe">{{ _('EU Mirror') }}</a>
-                          </li>
-                        </ul>
-                      </div>
+                      <a class="btn btn-primary btn-sm" href="https://data.musicbrainz.org/pub/musicbrainz/picard/MusicBrainz-Picard-{{beta.tag}}.exe">
+                        <i class="fa fa-windows"></i>&emsp;{{ _('Download') }}
+                      </a>
                     </td>
                   </tr>
                   {% endif %}
@@ -150,16 +110,9 @@
                     <td class="hidden-xs hidden-sm">{{stable.mac_hash}}</td>
                     <td>{{stable.mac_size}} MB</td>
                     <td>
-                      <div class="btn-group">
-                        <button type="button" class="btn btn-primary btn-sm dropdown-toggle" data-toggle="dropdown">
-                          <i class="fa fa-download"></i>&emsp;{{ _('Download') }}
-                          <span class="caret"></span>
-                        </button>
-                        <ul class="dropdown-menu" role="menu">
-                          <li><a href="https://musicbrainz.osuosl.org/pub/musicbrainz/picard/MusicBrainz-Picard-{{stable.tag}}-macOS-10.14.dmg">{{ _('US Mirror') }}</a></li>
-                          <li><a href="https://data.musicbrainz.org/pub/musicbrainz/picard/MusicBrainz-Picard-{{stable.tag}}-macOS-10.14.dmg">{{ _('EU Mirror') }}</a></li>
-                        </ul>
-                      </div>
+                      <a class="btn btn-primary btn-sm" href="https://data.musicbrainz.org/pub/musicbrainz/picard/MusicBrainz-Picard-{{stable.tag}}-macOS-10.14.dmg">
+                        <i class="fa fa-windows"></i>&emsp;{{ _('Download') }}
+                      </a>
                     </td>
                   </tr>
                   <tr>
@@ -167,16 +120,9 @@
                     <td class="hidden-xs hidden-sm">{{stable.mac_10_12_hash}}</td>
                     <td>{{stable.mac_10_12_size}} MB</td>
                     <td>
-                      <div class="btn-group">
-                        <button type="button" class="btn btn-primary btn-sm dropdown-toggle" data-toggle="dropdown">
-                          <i class="fa fa-download"></i>&emsp;{{ _('Download') }}
-                          <span class="caret"></span>
-                        </button>
-                        <ul class="dropdown-menu" role="menu">
-                          <li><a href="https://musicbrainz.osuosl.org/pub/musicbrainz/picard/MusicBrainz-Picard-{{stable.tag}}-macOS-10.12.dmg">{{ _('US Mirror') }}</a></li>
-                          <li><a href="https://data.musicbrainz.org/pub/musicbrainz/picard/MusicBrainz-Picard-{{stable.tag}}-macOS-10.12.dmg">{{ _('EU Mirror') }}</a></li>
-                        </ul>
-                      </div>
+                      <a class="btn btn-primary btn-sm" href="https://data.musicbrainz.org/pub/musicbrainz/picard/MusicBrainz-Picard-{{stable.tag}}-macOS-10.12.dmg">
+                        <i class="fa fa-windows"></i>&emsp;{{ _('Download') }}
+                      </a>
                     </td>
                   </tr>
                   <tr>
@@ -184,16 +130,9 @@
                     <td class="hidden-xs hidden-sm">4d781ca512c48fe4c3c00a432e80ed96</td>
                     <td>22 MB</td>
                     <td>
-                      <div class="btn-group">
-                        <button type="button" class="btn btn-primary btn-sm dropdown-toggle" data-toggle="dropdown">
-                          <i class="fa fa-download"></i>&emsp;{{ _('Download') }}
-                          <span class="caret"></span>
-                        </button>
-                        <ul class="dropdown-menu" role="menu">
-                          <li><a href="https://musicbrainz.osuosl.org/pub/musicbrainz/picard/MusicBrainz.Picard.2.1.3.dmg">{{ _('US Mirror') }}</a></li>
-                          <li><a href="https://data.musicbrainz.org/pub/musicbrainz/picard/MusicBrainz.Picard.2.1.3.dmg">{{ _('EU Mirror') }}</a></li>
-                        </ul>
-                      </div>
+                      <a class="btn btn-primary btn-sm" href="https://data.musicbrainz.org/pub/musicbrainz/picard/MusicBrainz.Picard.2.1.3.dmg">
+                        <i class="fa fa-windows"></i>&emsp;{{ _('Download') }}
+                      </a>
                     </td>
                   </tr>
                   {% if show_beta %}
@@ -202,20 +141,9 @@
                     <td class="hidden-xs hidden-sm">{{beta.mac_hash}}</td>
                     <td>{{beta.mac_size}} MB</td>
                     <td>
-                      <div class="btn-group">
-                        <button type="button" class="btn btn-primary btn-sm dropdown-toggle" data-toggle="dropdown">
-                          <i class="fa fa-download"></i>&emsp;{{ _('Download') }}
-                          <span class="caret"></span>
-                        </button>
-                        <ul class="dropdown-menu" role="menu">
-                          <li><a
-                              href="https://musicbrainz.osuosl.org/pub/musicbrainz/picard/MusicBrainz-Picard-{{beta.tag}}-macOS-10.14.dmg">{{ _('US Mirror') }}</a>
-                          </li>
-                          <li><a
-                              href="https://data.musicbrainz.org/pub/musicbrainz/picard/MusicBrainz-Picard-{{beta.tag}}-macOS-10.14.dmg">{{ _('EU Mirror') }}</a>
-                          </li>
-                        </ul>
-                      </div>
+                      <a class="btn btn-primary btn-sm" href="https://data.musicbrainz.org/pub/musicbrainz/picard/MusicBrainz-Picard-{{beta.tag}}-macOS-10.14.dmg">
+                        <i class="fa fa-windows"></i>&emsp;{{ _('Download') }}
+                      </a>
                     </td>
                   </tr>
                   <tr>
@@ -223,20 +151,9 @@
                     <td class="hidden-xs hidden-sm">{{beta.mac_10_12_hash}}</td>
                     <td>{{beta.mac_10_12_size}} MB</td>
                     <td>
-                      <div class="btn-group">
-                        <button type="button" class="btn btn-primary btn-sm dropdown-toggle" data-toggle="dropdown">
-                          <i class="fa fa-download"></i>&emsp;{{ _('Download') }}
-                          <span class="caret"></span>
-                        </button>
-                        <ul class="dropdown-menu" role="menu">
-                          <li>
-                            <a href="https://musicbrainz.osuosl.org/pub/musicbrainz/picard/MusicBrainz-Picard-{{beta.tag}}-macOS-10.12.dmg">{{ _('US Mirror') }}</a>
-                          </li>
-                          <li>
-                            <a href="https://data.musicbrainz.org/pub/musicbrainz/picard/MusicBrainz-Picard-{{beta.tag}}-macOS-10.12.dmg">{{ _('EU Mirror') }}</a>
-                          </li>
-                        </ul>
-                      </div>
+                      <a class="btn btn-primary btn-sm" href="https://data.musicbrainz.org/pub/musicbrainz/picard/MusicBrainz-Picard-{{beta.tag}}-macOS-10.12.dmg">
+                        <i class="fa fa-windows"></i>&emsp;{{ _('Download') }}
+                      </a>
                     </td>
                   </tr>
                   {% endif %}
@@ -388,16 +305,9 @@
                     <td class="hidden-xs hidden-sm">{{stable.source_tar_hash}}</td>
                     <td>{{stable.source_tar_size}} MB</td>
                     <td>
-                      <div class="btn-group">
-                        <button type="button" class="btn btn-primary btn-sm dropdown-toggle" data-toggle="dropdown">
-                          <i class="fa fa-download"></i>&emsp;{{ _('Download') }}
-                          <span class="caret"></span>
-                        </button>
-                        <ul class="dropdown-menu" role="menu">
-                          <li><a href="https://musicbrainz.osuosl.org/pub/musicbrainz/picard/picard-{{stable.tag}}.tar.gz">{{ _('US Mirror') }}</a></li>
-                          <li><a href="https://data.musicbrainz.org/pub/musicbrainz/picard/picard-{{stable.tag}}.tar.gz">{{ _('EU Mirror') }}</a></li>
-                        </ul>
-                      </div>
+                      <a class="btn btn-primary btn-sm" href="https://data.musicbrainz.org/pub/musicbrainz/picard/picard-{{stable.tag}}.tar.gz">
+                        <i class="fa fa-windows"></i>&emsp;{{ _('Download') }}
+                      </a>
                     </td>
                   </tr>
                   <tr>
@@ -405,16 +315,9 @@
                     <td class="hidden-xs hidden-sm">{{stable.source_zip_hash}}</td>
                     <td>{{stable.source_zip_size}} MB</td>
                     <td>
-                      <div class="btn-group">
-                        <button type="button" class="btn btn-primary btn-sm dropdown-toggle" data-toggle="dropdown">
-                          <i class="fa fa-download"></i>&emsp;{{ _('Download') }}
-                          <span class="caret"></span>
-                        </button>
-                        <ul class="dropdown-menu" role="menu">
-                          <li><a href="https://musicbrainz.osuosl.org/pub/musicbrainz/picard/picard-{{stable.tag}}.zip">{{ _('US Mirror') }}</a></li>
-                          <li><a href="https://data.musicbrainz.org/pub/musicbrainz/picard/picard-{{stable.tag}}.zip">{{ _('EU Mirror') }}</a></li>
-                        </ul>
-                      </div>
+                      <a class="btn btn-primary btn-sm" href="https://data.musicbrainz.org/pub/musicbrainz/picard/picard-{{stable.tag}}.zip">
+                        <i class="fa fa-windows"></i>&emsp;{{ _('Download') }}
+                      </a>
                     </td>
                   </tr>
                   {% if show_beta %}
@@ -423,16 +326,9 @@
                     <td class="hidden-xs hidden-sm">{{beta.source_tar_hash}}</td>
                     <td>{{beta.source_tar_size}} MB</td>
                     <td>
-                      <div class="btn-group">
-                        <button type="button" class="btn btn-primary btn-sm dropdown-toggle" data-toggle="dropdown">
-                          <i class="fa fa-download"></i>&emsp;{{ _('Download') }}
-                          <span class="caret"></span>
-                        </button>
-                        <ul class="dropdown-menu" role="menu">
-                          <li><a href="https://musicbrainz.osuosl.org/pub/musicbrainz/picard/picard-{{beta.tag}}.tar.gz">{{ _('US Mirror') }}</a></li>
-                          <li><a href="https://data.musicbrainz.org/pub/musicbrainz/picard/picard-{{beta.tag}}.tar.gz">{{ _('EU Mirror') }}</a></li>
-                        </ul>
-                      </div>
+                      <a class="btn btn-primary btn-sm" href="https://data.musicbrainz.org/pub/musicbrainz/picard/picard-{{beta.tag}}.tar.gz">
+                        <i class="fa fa-windows"></i>&emsp;{{ _('Download') }}
+                      </a>
                     </td>
                   </tr>
                   <tr>
@@ -440,16 +336,9 @@
                     <td class="hidden-xs hidden-sm">{{beta.source_zip_hash}}</td>
                     <td>{{beta.source_zip_size}} MB</td>
                     <td>
-                      <div class="btn-group">
-                        <button type="button" class="btn btn-primary btn-sm dropdown-toggle" data-toggle="dropdown">
-                          <i class="fa fa-download"></i>&emsp;{{ _('Download') }}
-                          <span class="caret"></span>
-                        </button>
-                        <ul class="dropdown-menu" role="menu">
-                          <li><a href="https://musicbrainz.osuosl.org/pub/musicbrainz/picard/picard-{{beta.tag}}.zip">{{ _('US Mirror') }}</a></li>
-                          <li><a href="https://data.musicbrainz.org/pub/musicbrainz/picard/picard-{{beta.tag}}.zip">{{ _('EU Mirror') }}</a></li>
-                        </ul>
-                      </div>
+                      <a class="btn btn-primary btn-sm" href="https://data.musicbrainz.org/pub/musicbrainz/picard/picard-{{beta.tag}}.zip">
+                        <i class="fa fa-windows"></i>&emsp;{{ _('Download') }}
+                      </a>
                     </td>
                   </tr>
                   {% endif %}
@@ -469,7 +358,7 @@
           </li>
         </ul>
         {% autoescape false %}
-        <p>{{ _("This page lists the most recent downloads. If you're looking for older versions of Picard, {url|browse our FTP server}.")|expand({'url': 'https://musicbrainz.osuosl.org/pub/musicbrainz/picard/?C=M;O=D'}) }}</p>
+        <p>{{ _("This page lists the most recent downloads. If you're looking for older versions of Picard, {url|browse our FTP server}.")|expand({'url': 'https://data.musicbrainz.org/pub/musicbrainz/picard/'}) }}</p>
         {% endautoescape %}
     </div><!-- /.container -->
 {% endblock %}

--- a/website/frontend/templates/downloads.html
+++ b/website/frontend/templates/downloads.html
@@ -32,7 +32,7 @@
                     <td class="hidden-xs hidden-sm">{{stable.win_hash}}</td>
                     <td>{{stable.win_size}} MB</td>
                     <td>
-                      <a class="btn btn-primary btn-sm" href="https://data.musicbrainz.org/pub/musicbrainz/picard/picard-setup-{{stable.tag}}.exe">
+                      <a class="btn btn-primary btn-sm" href="{{ config['FILESERVER_URL'] }}/picard-setup-{{stable.tag}}.exe">
                         <i class="fa fa-windows"></i>&emsp;{{ _('Download') }}
                       </a>
                     </td>
@@ -42,7 +42,7 @@
                     <td class="hidden-xs hidden-sm">{{stable.win_portable_hash}}</td>
                     <td>{{stable.win_portable_size}} MB</td>
                     <td>
-                      <a class="btn btn-primary btn-sm" href="https://data.musicbrainz.org/pub/musicbrainz/picard/MusicBrainz-Picard-{{stable.tag}}.exe">
+                      <a class="btn btn-primary btn-sm" href="{{ config['FILESERVER_URL'] }}/MusicBrainz-Picard-{{stable.tag}}.exe">
                         <i class="fa fa-windows"></i>&emsp;{{ _('Download') }}
                       </a>
                     </td>
@@ -67,7 +67,7 @@
                     <td class="hidden-xs hidden-sm">{{beta.win_hash}}</td>
                     <td>{{beta.win_size}} MB</td>
                     <td>
-                      <a class="btn btn-primary btn-sm" href="https://data.musicbrainz.org/pub/musicbrainz/picard/picard-setup-{{beta.tag}}.exe">
+                      <a class="btn btn-primary btn-sm" href="{{ config['FILESERVER_URL'] }}/picard-setup-{{beta.tag}}.exe">
                         <i class=" fa fa-windows"></i>&emsp;{{ _('Download') }}
                       </a>
                     </td>
@@ -77,7 +77,7 @@
                     <td class="hidden-xs hidden-sm">{{beta.win_portable_hash}}</td>
                     <td>{{beta.win_portable_size}} MB</td>
                     <td>
-                      <a class="btn btn-primary btn-sm" href="https://data.musicbrainz.org/pub/musicbrainz/picard/MusicBrainz-Picard-{{beta.tag}}.exe">
+                      <a class="btn btn-primary btn-sm" href="{{ config['FILESERVER_URL'] }}/MusicBrainz-Picard-{{beta.tag}}.exe">
                         <i class="fa fa-windows"></i>&emsp;{{ _('Download') }}
                       </a>
                     </td>
@@ -110,7 +110,7 @@
                     <td class="hidden-xs hidden-sm">{{stable.mac_hash}}</td>
                     <td>{{stable.mac_size}} MB</td>
                     <td>
-                      <a class="btn btn-primary btn-sm" href="https://data.musicbrainz.org/pub/musicbrainz/picard/MusicBrainz-Picard-{{stable.tag}}-macOS-10.14.dmg">
+                      <a class="btn btn-primary btn-sm" href="{{ config['FILESERVER_URL'] }}/MusicBrainz-Picard-{{stable.tag}}-macOS-10.14.dmg">
                         <i class="fa fa-windows"></i>&emsp;{{ _('Download') }}
                       </a>
                     </td>
@@ -120,7 +120,7 @@
                     <td class="hidden-xs hidden-sm">{{stable.mac_10_12_hash}}</td>
                     <td>{{stable.mac_10_12_size}} MB</td>
                     <td>
-                      <a class="btn btn-primary btn-sm" href="https://data.musicbrainz.org/pub/musicbrainz/picard/MusicBrainz-Picard-{{stable.tag}}-macOS-10.12.dmg">
+                      <a class="btn btn-primary btn-sm" href="{{ config['FILESERVER_URL'] }}/MusicBrainz-Picard-{{stable.tag}}-macOS-10.12.dmg">
                         <i class="fa fa-windows"></i>&emsp;{{ _('Download') }}
                       </a>
                     </td>
@@ -130,7 +130,7 @@
                     <td class="hidden-xs hidden-sm">4d781ca512c48fe4c3c00a432e80ed96</td>
                     <td>22 MB</td>
                     <td>
-                      <a class="btn btn-primary btn-sm" href="https://data.musicbrainz.org/pub/musicbrainz/picard/MusicBrainz.Picard.2.1.3.dmg">
+                      <a class="btn btn-primary btn-sm" href="{{ config['FILESERVER_URL'] }}/MusicBrainz.Picard.2.1.3.dmg">
                         <i class="fa fa-windows"></i>&emsp;{{ _('Download') }}
                       </a>
                     </td>
@@ -141,7 +141,7 @@
                     <td class="hidden-xs hidden-sm">{{beta.mac_hash}}</td>
                     <td>{{beta.mac_size}} MB</td>
                     <td>
-                      <a class="btn btn-primary btn-sm" href="https://data.musicbrainz.org/pub/musicbrainz/picard/MusicBrainz-Picard-{{beta.tag}}-macOS-10.14.dmg">
+                      <a class="btn btn-primary btn-sm" href="{{ config['FILESERVER_URL'] }}/MusicBrainz-Picard-{{beta.tag}}-macOS-10.14.dmg">
                         <i class="fa fa-windows"></i>&emsp;{{ _('Download') }}
                       </a>
                     </td>
@@ -151,7 +151,7 @@
                     <td class="hidden-xs hidden-sm">{{beta.mac_10_12_hash}}</td>
                     <td>{{beta.mac_10_12_size}} MB</td>
                     <td>
-                      <a class="btn btn-primary btn-sm" href="https://data.musicbrainz.org/pub/musicbrainz/picard/MusicBrainz-Picard-{{beta.tag}}-macOS-10.12.dmg">
+                      <a class="btn btn-primary btn-sm" href="{{ config['FILESERVER_URL'] }}/MusicBrainz-Picard-{{beta.tag}}-macOS-10.12.dmg">
                         <i class="fa fa-windows"></i>&emsp;{{ _('Download') }}
                       </a>
                     </td>
@@ -305,7 +305,7 @@
                     <td class="hidden-xs hidden-sm">{{stable.source_tar_hash}}</td>
                     <td>{{stable.source_tar_size}} MB</td>
                     <td>
-                      <a class="btn btn-primary btn-sm" href="https://data.musicbrainz.org/pub/musicbrainz/picard/picard-{{stable.tag}}.tar.gz">
+                      <a class="btn btn-primary btn-sm" href="{{ config['FILESERVER_URL'] }}/picard-{{stable.tag}}.tar.gz">
                         <i class="fa fa-windows"></i>&emsp;{{ _('Download') }}
                       </a>
                     </td>
@@ -315,7 +315,7 @@
                     <td class="hidden-xs hidden-sm">{{stable.source_zip_hash}}</td>
                     <td>{{stable.source_zip_size}} MB</td>
                     <td>
-                      <a class="btn btn-primary btn-sm" href="https://data.musicbrainz.org/pub/musicbrainz/picard/picard-{{stable.tag}}.zip">
+                      <a class="btn btn-primary btn-sm" href="{{ config['FILESERVER_URL'] }}/picard-{{stable.tag}}.zip">
                         <i class="fa fa-windows"></i>&emsp;{{ _('Download') }}
                       </a>
                     </td>
@@ -326,7 +326,7 @@
                     <td class="hidden-xs hidden-sm">{{beta.source_tar_hash}}</td>
                     <td>{{beta.source_tar_size}} MB</td>
                     <td>
-                      <a class="btn btn-primary btn-sm" href="https://data.musicbrainz.org/pub/musicbrainz/picard/picard-{{beta.tag}}.tar.gz">
+                      <a class="btn btn-primary btn-sm" href="{{ config['FILESERVER_URL'] }}/picard-{{beta.tag}}.tar.gz">
                         <i class="fa fa-windows"></i>&emsp;{{ _('Download') }}
                       </a>
                     </td>
@@ -336,7 +336,7 @@
                     <td class="hidden-xs hidden-sm">{{beta.source_zip_hash}}</td>
                     <td>{{beta.source_zip_size}} MB</td>
                     <td>
-                      <a class="btn btn-primary btn-sm" href="https://data.musicbrainz.org/pub/musicbrainz/picard/picard-{{beta.tag}}.zip">
+                      <a class="btn btn-primary btn-sm" href="{{ config['FILESERVER_URL'] }}/picard-{{beta.tag}}.zip">
                         <i class="fa fa-windows"></i>&emsp;{{ _('Download') }}
                       </a>
                     </td>
@@ -358,7 +358,7 @@
           </li>
         </ul>
         {% autoescape false %}
-        <p>{{ _("This page lists the most recent downloads. If you're looking for older versions of Picard, {url|browse our FTP server}.")|expand({'url': 'https://data.musicbrainz.org/pub/musicbrainz/picard/'}) }}</p>
+        <p>{{ _("This page lists the most recent downloads. If you're looking for older versions of Picard, {url|browse our FTP server}.")|expand({'url': config['FILESERVER_URL']}) }}</p>
         {% endautoescape %}
     </div><!-- /.container -->
 {% endblock %}

--- a/website/frontend/templates/index.html
+++ b/website/frontend/templates/index.html
@@ -143,7 +143,7 @@
       var platform = navigator.platform, downloadURL, iconClass, infoText;
 
       if (/^Win/.test(platform) || /Windows/.test(navigator.userAgent)) {
-        downloadURL = "https://data.musicbrainz.org/pub/musicbrainz/picard/picard-setup-{{tag}}.exe";
+        downloadURL = "{{ config['FILESERVER_URL'] }}/picard-setup-{{tag}}.exe";
         iconClass = "fa-windows";
         infoText = {{_('v{version} for Windows (64-bit)')|expand({'version': tag})|tojson}};
 
@@ -153,7 +153,7 @@
         infoText = {{_('v{version} for Linux Distributions')|expand({'version': tag})|tojson}};
 
       } else if (platform === "MacIntel" || platform === "MacPPC") {
-        downloadURL = "https://data.musicbrainz.org/pub/musicbrainz/picard/MusicBrainz-Picard-{{tag}}-macOS-10.14.dmg";
+        downloadURL = "{{ config['FILESERVER_URL'] }}/MusicBrainz-Picard-{{tag}}-macOS-10.14.dmg";
         iconClass = "fa-apple";
         infoText = {{_('v{version} for macOS 10.14+')|expand({'version': tag})|tojson}};
       }

--- a/website/frontend/templates/index.html
+++ b/website/frontend/templates/index.html
@@ -143,7 +143,7 @@
       var platform = navigator.platform, downloadURL, iconClass, infoText;
 
       if (/^Win/.test(platform) || /Windows/.test(navigator.userAgent)) {
-        downloadURL = "https://musicbrainz.osuosl.org/pub/musicbrainz/picard/picard-setup-{{tag}}.exe";
+        downloadURL = "https://data.musicbrainz.org/pub/musicbrainz/picard/picard-setup-{{tag}}.exe";
         iconClass = "fa-windows";
         infoText = {{_('v{version} for Windows (64-bit)')|expand({'version': tag})|tojson}};
 
@@ -153,7 +153,7 @@
         infoText = {{_('v{version} for Linux Distributions')|expand({'version': tag})|tojson}};
 
       } else if (platform === "MacIntel" || platform === "MacPPC") {
-        downloadURL = "https://musicbrainz.osuosl.org/pub/musicbrainz/picard/MusicBrainz-Picard-{{tag}}-macOS-10.14.dmg";
+        downloadURL = "https://data.musicbrainz.org/pub/musicbrainz/picard/MusicBrainz-Picard-{{tag}}-macOS-10.14.dmg";
         iconClass = "fa-apple";
         infoText = {{_('v{version} for macOS 10.14+')|expand({'version': tag})|tojson}};
       }


### PR DESCRIPTION
<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard Website. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [picard/CONTRIBUTING.md](https://github.com/metabrainz/picard-website/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): PW-105
<!--
    Please make sure you prefix your pull request title with 'PW-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

The US mirror is no longer available.


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->

Remove the links to the US server and only link to https://data.musicbrainz.org/pub/musicbrainz/picard/

Also made this base URL a configuration option, so it will be easier to update it in the future