### PR TITLE
Fix uWSGI configuration for clean shutdown

### DIFF
--- a/docker/uwsgi.ini
+++ b/docker/uwsgi.ini
@@ -1,4 +1,6 @@
 [uwsgi]
+uid = www-data
+gid = www-data
 master = true
 socket = 0.0.0.0:3031
 module = website.frontend
@@ -6,3 +8,8 @@ callable = create_app()
 chdir = /code/website/
 processes = 20
 enable-threads = true
+log-x-forwarded-for=true
+; quit uwsgi if the python app fails to load
+need-app = true
+; when uwsgi gets a sighup, quit completely and let runit restart us
+exit-on-reload = true


### PR DESCRIPTION
In absence of the exit-on-reload configuration option, uWSGI does not exit cleanly when consul-template attempts to restart it. This manifests as an error like: bind(): Address already in use [core/socket.c line 769]. Fix the configuration appropriately.