### PR TITLE
PW-41: Plugins table made sortable. [FEAT]

### DIFF
--- a/website/frontend/templates/base.html
+++ b/website/frontend/templates/base.html
@@ -6,6 +6,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="{{ _('Official website for MusicBrainz Picard, a cross-platform music tagger written in Python.') }}">
     <meta name="author" href="{{ url_for('humans.show_humans') }}">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/js-cookie/3.0.1/js.cookie.min.js"></script>
+    <script src="https://code.jquery.com/jquery-3.7.0.js"></script>
+    <link rel="stylesheet" type="text/css" href="https:///cdn.datatables.net/1.13.7/css/jquery.dataTables.min.css">
+    <script type="text/javascript" charset="utf8" src="https://cdn.datatables.net/1.13.7/js/jquery.dataTables.min.js"></script>
     <link rel="icon" type="image/png" href="{{ url_for('static', filename='img/picard-icon.png') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}">
     <title>{% block title %}{% if page_title is defined %}{{page_title}} - {%endif%}{{ _('MusicBrainz Picard') }}{% endblock %}</title>

--- a/website/frontend/templates/plugins.html
+++ b/website/frontend/templates/plugins.html
@@ -21,8 +21,9 @@
         <div class="tab-content">
         {% for version, plugins in all_plugins.items() %}
           <div class="tab-pane {{'active' if version == '2' }}" id="apiv{{version}}">
+            <br/>
             <div class="table-responsive">
-              <table class="table table-bordered table-hover">
+              <table id="plugins-table-v{{version}}" class="table table-bordered table-hover">
                 <col width="175px" name="Name"/>
                 <col width="100px" name="Version"/>
                 <col width="500px" name="Description"/>
@@ -30,11 +31,11 @@
                 <col width="100px" name="Download"/>
                 <thead>
                   <tr>
-                    <th class="text-center">{{ _("Name") }}</th>
-                    <th class="text-center">{{ _("Version") }}</th>
-                    <th class="text-center">{{ _("Description") }}</th>
+                    <th class="text-center" data-sortable="true">{{ _("Name") }}</th>
+                    <th class="text-center" data-sortable="true">{{ _("Version") }}</th>
+                    <th class="text-center" data-sortable="true">{{ _("Description") }}</th>
                     <th class="text-center">{{ _("Author(s)") }}</th>
-                    <th class="text-center"></th>
+                    <th class="text-center" data-sortable="false"></th>
                   </tr>
                 </thead>
                 <tbody>
@@ -53,6 +54,19 @@
                 {% endfor %}
                 </tbody>
               </table>
+              <script type="text/javascript">
+                (function f(version) {
+                    let storedSort = Cookies.get('userSortPreference-v' + version);
+
+                    let dataTable = new DataTable('#plugins-table-v{{version}}', {
+                          "order": storedSort ? JSON.parse(storedSort) : []
+                    })
+
+                    dataTable.on('click', 'thead th', function () {
+                        Cookies.set('userSortPreference-v' + version, JSON.stringify(dataTable.order()));
+                    });
+                })({{version}})
+              </script>
             </div>
           </div>
         {% endfor %}
@@ -60,3 +74,4 @@
       </div>
     </div>
 {% endblock %}
+


### PR DESCRIPTION
# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…

    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**: Made the columns of the plugins table sortable and also make them persist upon page reloads, based onuser preference.

# Problem
* **JIRA ticket: [PW-41](https://tickets.metabrainz.org/browse/PW-41):**
&nbsp;&nbsp;&nbsp;&nbsp;*Basically the issue addresses the unavailability of a sort feature for each column of the plugins table.*

Noticed that this ticket has been open for so long and hence wanted to contribute to it.

# Solution

I noticed that there is already a PR open for this particular ticket. #294 

However what this PR fails to solve is the following part which is requested along with the ticket.

![image](https://github.com/metabrainz/picard-website/assets/120002392/400f5fc3-00ad-41c5-9560-e2e6074f9a55)

Therefore, taking the opportunity to improvise by adding the above requested feature.

# Proof

Below shows the screenshots corresponding to this PR.

![image](https://github.com/metabrainz/picard-website/assets/120002392/4acc5c77-505f-41b3-885b-8f4aa685f880)

# Action

Please take a look **(PTAL)** and kindly give any feedback if possible.
