### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -1,10 +1,13 @@
 name: Docker Image CI
+permissions:
+  contents: read
+  packages: write
 
 on:
   push:
     branches: [ master ]
     tags:
-      - 'v[0-9]+.*'
+     - 'v[0-9]+.*'
 
 jobs:
 


### PR DESCRIPTION
Potential fix for [https://github.com/metabrainz/picard-website/security/code-scanning/1](https://github.com/metabrainz/picard-website/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the steps in the workflow, the following permissions are needed:
- `contents: read` for accessing the repository's contents.
- `packages: write` for pushing Docker images to a registry.

The `permissions` block will be added after the `name` field at the top of the file to apply these permissions to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
