### PR TITLE
Use separate SCHEDULER_API_ALLOWED_HOSTS to restrict scheduler API access

### DIFF
--- a/website/default_config.py
+++ b/website/default_config.py
@@ -120,4 +120,4 @@ SERVER_PORT = 6060
 # Scheduler API is restricted to localhost only (see scheduler.py)
 # Safe to enable for local debugging and monitoring
 SCHEDULER_API_ENABLED = False
-SCHEDULER_ALLOWED_HOSTS = ['127.0.0.1', 'localhost', '::1']
+SCHEDULER_API_ALLOWED_HOSTS = ['127.0.0.1', 'localhost', '::1']

--- a/website/frontend/scheduler.py
+++ b/website/frontend/scheduler.py
@@ -1,7 +1,7 @@
 from flask import request
 from flask_apscheduler import APScheduler
 
-from website.build_plugins import generate_plugins
+from website.build_plugins import VERSION_INFO, generate_plugins
 from website.plugin_utils import load_json_data
 
 
@@ -27,6 +27,9 @@ def init_scheduler(app):
         versions = [z['title'] for z in config['PLUGIN_VERSIONS'].values()]
         build_dir = config['PLUGINS_BUILD_DIR']
         for version in versions:
+            # Only generate for versions using the build system (v3+ use remote registry)
+            if version not in VERSION_INFO:
+                continue
             logger.info("Generating plugins for version %s in %s", version, build_dir)
             try:
                 generate_plugins(build_dir, version)

--- a/website/frontend/scheduler.py
+++ b/website/frontend/scheduler.py
@@ -15,7 +15,7 @@ def init_scheduler(app):
     @app.before_request
     def restrict_scheduler_api():
         if request.path.startswith('/scheduler'):
-            allowed_hosts = config.get('SCHEDULER_ALLOWED_HOSTS', ['127.0.0.1', 'localhost', '::1'])
+            allowed_hosts = config.get('SCHEDULER_API_ALLOWED_HOSTS', ['127.0.0.1', 'localhost', '::1'])
             if request.remote_addr not in allowed_hosts:
                 logger.warning('Scheduler API access denied from %s to %s', request.remote_addr, request.path)
                 from flask import abort


### PR DESCRIPTION


<!--
    Hello! Thanks for submitting a pull request to MusicBrainz Picard Website. We
    appreciate your time and interest in helping our project!

    Use this template to help us review your change. Not everything is required,
    depending on your change. Keep or delete what is relevant for your change.
    Remember that it helps us review if you give more helpful info for us to
    understand your change.

    Ensure that you've read through and followed the Contributing Guidelines, in
    [picard/CONTRIBUTING.md](https://github.com/metabrainz/picard-website/blob/master/CONTRIBUTING.md).
-->

# Summary

<!--
    Update the checkbox with an [x] for the type of contribution you are making.
-->

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

<!--
    Anything that helps us understand why you are making this change goes here.
    What problem are you trying to fix? What does this change address?
-->

* JIRA ticket (_optional_): [PW-XXX](https://tickets.metabrainz.org/browse/PW-XXX)
<!--
    Please make sure you prefix your pull request title with 'PW-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->

Scheduler is not running


# Solution

<!--
    The details of your change. Talk about technical details, considerations, or
    other interesting points. If you have a lot to say, be more detailed in this
    section.
-->
SCHEDULER_ALLOWED_HOSTS would restrict running the scheduler itself. Hence add a new SCHEDULER_API_ALLOWED_HOSTS that restricts access only to the scheduler API (which is disabled by default).

# Action

<!--
    Other than merging your change, do you want / need us to do anything else
    with your change? This could include reviewing a specific part of your PR.
-->

