### PR TITLE
Prepare for uwsgi->HTTP migration: dual-socket + /healthz

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,5 +58,5 @@ RUN rm -rf ./node_modules .pytest_cache .coverage \
     && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/*
 
-EXPOSE 3031
+EXPOSE 3031 3032
 CMD ["uwsgi", "/etc/uwsgi/uwsgi.ini"]

--- a/docker/uwsgi.ini
+++ b/docker/uwsgi.ini
@@ -2,7 +2,10 @@
 uid = www-data
 gid = www-data
 master = true
+; uwsgi binary protocol (legacy) — kept during the uwsgi->HTTP transition
 socket = 0.0.0.0:3031
+; plain HTTP — the migration target (see syswiki UwsgiToHttpMigration.md)
+http-socket = 0.0.0.0:3032
 module = website.frontend
 callable = create_app()
 chdir = /code/website/

--- a/website/config.py.example
+++ b/website/config.py.example
@@ -78,3 +78,8 @@
 ## Scheduler API is restricted to localhost only (see scheduler.py)
 ## Safe to enable for local debugging and monitoring
 #SCHEDULER_API_ENABLED = True
+#
+## /healthz access control (see frontend/healthz.py). CIDR ranges / IPs allowed
+## to reach the health endpoint. Default (in default_config.py) allows loopback
+## and the RFC1918 private ranges. Set to [] to allow everyone (local dev).
+#HEALTH_ALLOWED_IPS = ['127.0.0.0/8', '::1/128', '10.0.0.0/8', '172.16.0.0/12', '192.168.0.0/16']

--- a/website/default_config.py
+++ b/website/default_config.py
@@ -121,3 +121,16 @@ SERVER_PORT = 6060
 # Safe to enable for local debugging and monitoring
 SCHEDULER_API_ENABLED = False
 SCHEDULER_API_ALLOWED_HOSTS = ['127.0.0.1', 'localhost', '::1']
+
+# /healthz access control (see frontend/healthz.py).
+# List of CIDR ranges / IPs allowed to reach the health endpoint. The Consul
+# check connects directly to the backend on the internal (VLAN) address, so the
+# default allows loopback and the RFC1918 private ranges and blocks the public
+# internet. Set to [] to allow everyone (e.g. for local development).
+HEALTH_ALLOWED_IPS = [
+    '127.0.0.0/8',
+    '::1/128',
+    '10.0.0.0/8',
+    '172.16.0.0/12',
+    '192.168.0.0/16',
+]

--- a/website/frontend/__init__.py
+++ b/website/frontend/__init__.py
@@ -4,6 +4,7 @@ from flask import Flask
 
 from .babel import init_app
 from .errors import init_error_handlers
+from .healthz import init_healthz
 from .scheduler import init_scheduler
 
 
@@ -20,7 +21,7 @@ def create_app(config_overrides=None):
     # Configuration files
     app.config.from_pyfile(os.path.join(website_folder, 'default_config.py'))
     app.config.from_pyfile(os.path.join(website_folder, 'config.py'), silent=True)
-    
+
     # Apply config overrides (for testing)
     if config_overrides:
         app.config.update(config_overrides)
@@ -43,6 +44,9 @@ def create_app(config_overrides=None):
 
     # Initialize scheduler
     init_scheduler(app)
+
+    # Health check endpoint (/healthz)
+    init_healthz(app)
 
     # Template utilities
     app.jinja_env.add_extension('jinja2.ext.do')

--- a/website/frontend/healthz.py
+++ b/website/frontend/healthz.py
@@ -1,0 +1,64 @@
+"""Health check endpoint.
+
+A small, cheap, side-effect-free endpoint used by Consul health checks (and the
+uwsgi->HTTP migration's protocol probe — see syswiki UwsgiToHttpMigration.md).
+
+It is intentionally kept out of `/` (no templates, no dependencies) so it stays
+fast and cannot be broken by a slow home page.
+
+Access is restricted to configured IP ranges via ``HEALTH_ALLOWED_IPS`` — the
+check reaches the backend directly on its (internal) address, so the default
+allows loopback and the private ranges. An empty list allows everyone.
+
+This mirrors the scheduler API restriction (see ``scheduler.py``): a
+``before_request`` guard keyed on the path, using ``request.remote_addr``
+(never a spoofable ``X-Forwarded-For``), logging a warning and returning 403.
+Unlike the scheduler's exact-host list, the health allow-list supports CIDR
+**ranges**, which are parsed once at init.
+"""
+
+import ipaddress
+
+from flask import abort, request
+
+
+def _parse_networks(values, logger):
+    """Parse CIDR/IP strings into ip_network objects, skipping (and logging) bad ones."""
+    networks = []
+    for value in values or []:
+        try:
+            networks.append(ipaddress.ip_network(value, strict=False))
+        except ValueError:
+            logger.warning("HEALTH_ALLOWED_IPS: ignoring invalid entry %r", value)
+    return networks
+
+
+def _is_allowed(client_ip, allowed_networks):
+    """True if ``client_ip`` is within any of ``allowed_networks`` (empty = allow all)."""
+    if not allowed_networks:
+        return True
+    if client_ip is None:
+        return False
+    try:
+        addr = ipaddress.ip_address(client_ip)
+    except ValueError:
+        return False
+    return any(addr in net for net in allowed_networks)
+
+
+def init_healthz(app):
+    logger = app.logger
+    # Parse the allow-list once; config does not change at runtime.
+    allowed_networks = _parse_networks(app.config.get('HEALTH_ALLOWED_IPS'), logger)
+
+    # Restrict the health endpoint to allowed IP ranges only.
+    @app.before_request
+    def restrict_healthz():
+        if request.path == '/healthz':
+            if not _is_allowed(request.remote_addr, allowed_networks):
+                logger.warning('Health check access denied from %s', request.remote_addr)
+                abort(403)
+
+    @app.get('/healthz')
+    def healthz():
+        return 'ok\n', 200, {'Content-Type': 'text/plain; charset=utf-8'}

--- a/website/frontend/healthz_test.py
+++ b/website/frontend/healthz_test.py
@@ -1,0 +1,77 @@
+import ipaddress
+import logging
+
+from website.frontend import create_app
+from website.frontend.healthz import _is_allowed, _parse_networks
+
+
+class _App:
+    """Minimal helper to build an app with specific HEALTH_ALLOWED_IPS."""
+
+    @staticmethod
+    def client(allowed_ips):
+        app = create_app(config_overrides={'TESTING': True, 'HEALTH_ALLOWED_IPS': allowed_ips})
+        return app.test_client()
+
+
+def test_healthz_allowed_from_loopback():
+    # 127.0.0.1 (the test client default) is inside 127.0.0.0/8
+    client = _App.client(['127.0.0.0/8'])
+    resp = client.get('/healthz')
+    assert resp.status_code == 200
+    assert resp.data == b'ok\n'
+
+
+def test_healthz_denied_from_outside_range():
+    client = _App.client(['10.0.0.0/8'])  # loopback not included
+    resp = client.get('/healthz', environ_overrides={'REMOTE_ADDR': '8.8.8.8'})
+    assert resp.status_code == 403
+
+
+def test_healthz_allowed_within_range():
+    client = _App.client(['10.0.0.0/8'])
+    resp = client.get('/healthz', environ_overrides={'REMOTE_ADDR': '10.2.2.20'})
+    assert resp.status_code == 200
+
+
+def test_healthz_empty_list_allows_all():
+    client = _App.client([])
+    resp = client.get('/healthz', environ_overrides={'REMOTE_ADDR': '203.0.113.1'})
+    assert resp.status_code == 200
+
+
+def test_healthz_ignores_x_forwarded_for():
+    # An outside peer must not bypass the allow-list by spoofing X-Forwarded-For.
+    client = _App.client(['10.0.0.0/8'])
+    resp = client.get(
+        '/healthz',
+        environ_overrides={'REMOTE_ADDR': '8.8.8.8'},
+        headers={'X-Forwarded-For': '10.2.2.20'},
+    )
+    assert resp.status_code == 403
+
+
+# --- unit tests for the helpers ---
+
+
+def test_is_allowed_empty_means_all():
+    assert _is_allowed('8.8.8.8', []) is True
+
+
+def test_is_allowed_membership():
+    nets = [ipaddress.ip_network('10.0.0.0/8')]
+    assert _is_allowed('10.9.9.9', nets) is True
+    assert _is_allowed('11.0.0.1', nets) is False
+
+
+def test_is_allowed_bad_ip():
+    nets = [ipaddress.ip_network('10.0.0.0/8')]
+    assert _is_allowed('not-an-ip', nets) is False
+    assert _is_allowed(None, nets) is False
+
+
+def test_parse_networks_skips_invalid(caplog):
+    logger = logging.getLogger('test')
+    with caplog.at_level(logging.WARNING):
+        nets = _parse_networks(['10.0.0.0/8', 'garbage', '192.168.0.0/16'], logger)
+    assert len(nets) == 2


### PR DESCRIPTION
Prepares picard-website for the uwsgi→HTTP migration
(see syswiki `UwsgiToHttpMigration.md`).

## Changes

**1. Dual-socket uWSGI (`docker/uwsgi.ini`, `Dockerfile`)**

Serve both protocols from the one uWSGI master during the transition:

```ini
socket      = 0.0.0.0:3031   ; uwsgi binary protocol (legacy)
http-socket = 0.0.0.0:3032   ; plain HTTP (target)
```

`EXPOSE 3031 3032`. No app behaviour change. Once deployment registers both an
`<env>-uwsgi` and `<env>-http` view, the gateway's `proto:auto` selector
switches to HTTP by health check with zero downtime; the uwsgi socket is dropped
afterwards.

**2. `/healthz` endpoint with configurable IP-range protection**

A small, cheap, side-effect-free health endpoint (plain-text `ok`, kept out of
`/`) for Consul health checks and the migration's HTTP protocol probe.

- Access restricted to CIDR ranges in `HEALTH_ALLOWED_IPS` (default: loopback +
  RFC1918 private ranges; `[]` = allow all). The Consul check reaches the
  backend directly on its internal address, so this blocks the public internet
  while letting the VLAN through.
- Mirrors the existing scheduler-API restriction (`before_request` guard,
  `request.remote_addr`, warning + 403) but supports **ranges**. Uses
  `remote_addr`, never a spoofable `X-Forwarded-For`. Ranges parsed once at init.
- Config documented in `default_config.py` and `config.py.example`.

## Tests

9 new unit tests (`website/frontend/healthz_test.py`): allowed/denied/allow-all,
X-Forwarded-For cannot bypass, helper edge cases. Full suite **84 passed**, ruff
clean.

## Deploy dependency

The gateway switch relies on the two infra PRs (land first):
metabrainz/openresty-gateways#50 (`proto:"auto"`) and
metabrainz/serviceregistrator#26 (`proto=http` default check). The
`docker-server-configs` `services.sh`/`constants.sh` changes (publish the 2nd
port, register both views, `proto:"auto"` in `config.prod.json`) are done at
deploy time per the runbook, not in this repo.