### PR TITLE
Enable granian access logs; make debug mode env-configurable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,6 +65,12 @@ RUN rm -rf ./node_modules .pytest_cache .coverage \
 # may prefer 1 worker per container and scaling containers instead.
 USER www-data:www-data
 ENV GRANIAN_WORKERS=4
+# Access logging on by default (granian disables it otherwise). The format
+# mirrors uwsgi's log-x-forwarded-for: %(addr)s is the immediate peer (the
+# reverse proxy), and xff carries the real client chain from X-Forwarded-For.
+# Both are overridable/disableable at runtime via these GRANIAN_* env vars.
+ENV GRANIAN_LOG_ACCESS_ENABLED=true
+ENV GRANIAN_LOG_ACCESS_FMT="[%(time)s] %(addr)s xff=%(header{x-forwarded-for})s \"%(method)s %(path)s %(protocol)s\" %(status)d %(dt_ms).3f"
 EXPOSE 3031
 CMD ["/code/website/.venv/bin/granian", \
      "--interface", "wsgi", \

--- a/website/config.py.example
+++ b/website/config.py.example
@@ -1,4 +1,8 @@
 #
+## Flask debug mode. OFF by default (production). Also toggleable via the
+## PICARD_WEBSITE_DEBUG env var, which takes precedence when set.
+#DEBUG = False
+#
 ## Default cache timeout - used when no specific timeout is specified
 #DEFAULT_CACHE_TIMEOUT = 5 * 60
 #

--- a/website/default_config.py
+++ b/website/default_config.py
@@ -2,6 +2,11 @@
 # You need to copy config.py.example to config.py and edit the file to your own needs
 # to override these values.
 
+# Flask debug mode. OFF by default for production (no interactive debugger on
+# tracebacks, no verbose logging). Can also be toggled at runtime with the
+# PICARD_WEBSITE_DEBUG env var, which takes precedence when set.
+DEBUG = False
+
 # Default cache timeout - used when no specific timeout is specified
 DEFAULT_CACHE_TIMEOUT = 5 * 60
 

--- a/website/frontend/__init__.py
+++ b/website/frontend/__init__.py
@@ -14,9 +14,16 @@ template_folder = os.path.join(frontend_folder, 'templates')
 static_folder = os.path.join(frontend_folder, 'static')
 
 
+def _env_flag(name):
+    """Return True/False if the env var is set to a recognised value, else None."""
+    value = os.environ.get(name)
+    if value is None:
+        return None
+    return value.strip().lower() in ('1', 'true', 'yes', 'on')
+
+
 def create_app(config_overrides=None):
     app = Flask(__name__, static_folder=static_folder, template_folder=template_folder)
-    app.debug = True
 
     # Configuration files
     app.config.from_pyfile(os.path.join(website_folder, 'default_config.py'))
@@ -25,6 +32,15 @@ def create_app(config_overrides=None):
     # Apply config overrides (for testing)
     if config_overrides:
         app.config.update(config_overrides)
+
+    # Debug mode is OFF by default (safe for production: no interactive
+    # debugger on tracebacks, no verbose logging). Enable via the DEBUG config
+    # value or, for docker deployments, the PICARD_WEBSITE_DEBUG env var, which
+    # takes precedence when set.
+    env_debug = _env_flag('PICARD_WEBSITE_DEBUG')
+    if env_debug is not None:
+        app.config['DEBUG'] = env_debug
+    app.debug = app.config.get('DEBUG', False)
 
     # Error handling
     init_error_handlers(app)

--- a/website/frontend/app_config_test.py
+++ b/website/frontend/app_config_test.py
@@ -1,0 +1,39 @@
+from website.frontend import _env_flag, create_app
+
+
+def test_debug_off_by_default():
+    # default_config.py sets DEBUG = False; no override, no env var.
+    app = create_app(config_overrides={'TESTING': True})
+    assert app.debug is False
+
+
+def test_debug_on_via_config_override():
+    app = create_app(config_overrides={'TESTING': True, 'DEBUG': True})
+    assert app.debug is True
+
+
+def test_debug_env_var_takes_precedence_on(monkeypatch):
+    # Env var overrides even a config value of False.
+    monkeypatch.setenv('PICARD_WEBSITE_DEBUG', '1')
+    app = create_app(config_overrides={'TESTING': True, 'DEBUG': False})
+    assert app.debug is True
+
+
+def test_debug_env_var_takes_precedence_off(monkeypatch):
+    monkeypatch.setenv('PICARD_WEBSITE_DEBUG', 'false')
+    app = create_app(config_overrides={'TESTING': True, 'DEBUG': True})
+    assert app.debug is False
+
+
+def test_env_flag_recognised_values(monkeypatch):
+    for truthy in ('1', 'true', 'TRUE', 'Yes', 'on'):
+        monkeypatch.setenv('PICARD_WEBSITE_DEBUG', truthy)
+        assert _env_flag('PICARD_WEBSITE_DEBUG') is True
+    for falsy in ('0', 'false', 'no', 'off', ''):
+        monkeypatch.setenv('PICARD_WEBSITE_DEBUG', falsy)
+        assert _env_flag('PICARD_WEBSITE_DEBUG') is False
+
+
+def test_env_flag_unset_returns_none(monkeypatch):
+    monkeypatch.delenv('PICARD_WEBSITE_DEBUG', raising=False)
+    assert _env_flag('PICARD_WEBSITE_DEBUG') is None


### PR DESCRIPTION
# Summary

* This is a…
    * [x] Bug fix
    * [ ] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**: Follow-up to the granian migration — restore request access logging (granian disables it by default) and stop running the app with `debug=True` in production. Both are env-configurable for docker.

# Problem

After moving to granian:

1. **No access logs.** granian's access log is disabled by default (`--access-log / default: disabled`), so requests were no longer logged the way uWSGI logged them.
2. **`app.debug = True` unconditionally.** `create_app()` set debug mode on for everyone. For a public production service this is unsafe: the Werkzeug interactive debugger is exposed on unhandled exceptions (potential RCE surface) and logging is verbose. This predates the migration but is worth fixing now that we're modernizing the serving layer.

# Solution

**Access logs** (Dockerfile, env-driven):
- `ENV GRANIAN_LOG_ACCESS_ENABLED=true` — on by default.
- `ENV GRANIAN_LOG_ACCESS_FMT="[%(time)s] %(addr)s xff=%(header{x-forwarded-for})s \"%(method)s %(path)s %(protocol)s\" %(status)d %(dt_ms).3f"`.

  granian evaluates `%(addr)s` from the connection peer (the reverse proxy), *before* our `wrap_wsgi_with_proxy_headers` rewrite, so it would show the proxy. To capture the real client we log the `X-Forwarded-For` header directly via the `header{...}` atom (`xff=`), mirroring uWSGI's `log-x-forwarded-for`. Both env vars can be overridden/disabled at runtime.

**Debug mode** (config + env, defaults off):
- `DEBUG = False` in `default_config.py`.
- `create_app()` sets `app.debug` from config, with the `PICARD_WEBSITE_DEBUG` env var taking precedence when set (recognises `1/true/yes/on` etc.). Documented in `config.py.example`.
- Added `app_config_test.py` covering the config default, config override, env-var precedence (both directions), and the `_env_flag` helper.

# Verification

- `ruff` clean; `pytest` 90 passed (84 + 6 new).
- In-container:
  - Access log shows `xff=-` without a forwarded header and `xff=203.0.113.9, 10.0.0.5` with one.
  - Default run: no `DEBUG in …` output / no debugger (debug off). `-e PICARD_WEBSITE_DEBUG=1`: debug lines reappear (debug on).

# Action

No deploy-config change required — the new env vars have safe built-in defaults. Ops can set `PICARD_WEBSITE_DEBUG`, `GRANIAN_LOG_ACCESS_ENABLED`, or `GRANIAN_LOG_ACCESS_FMT` per-container if needed.
