### PR TITLE
Offload /static to granian with content-hash cache-busting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,9 +72,22 @@ ENV GRANIAN_WORKERS=4
 ENV GRANIAN_LOG_ACCESS_ENABLED=true
 ENV GRANIAN_LOG_ACCESS_FMT="[%(time)s] %(addr)s xff=%(header{x-forwarded-for})s \"%(method)s %(path)s %(protocol)s\" %(status)d %(dt_ms).3f"
 EXPOSE 3031
+# Offload /static/* directly to granian (served from Rust, bypassing the Python
+# app) instead of Flask's static view. The mount path is relative to WORKDIR
+# (/code/website) and matches Flask's static_folder, so url_for('static', ...)
+# still generates /static/... URLs that granian intercepts.
+#
+# Assets use a long cache lifetime (30 days). This is safe because create_app()
+# appends ?v=<content-hash> to every static URL (see static_versioning.py): when
+# a file changes its URL changes, so clients never serve a stale asset across
+# releases. granian ignores the query string when serving the file. Override
+# GRANIAN_STATIC_PATH_EXPIRES to change the lifetime.
+ENV GRANIAN_STATIC_PATH_EXPIRES=2592000
 CMD ["/code/website/.venv/bin/granian", \
      "--interface", "wsgi", \
      "--factory", \
      "--host", "0.0.0.0", \
      "--port", "3031", \
+     "--static-path-route", "/static", \
+     "--static-path-mount", "website/frontend/static", \
      "website.wsgi:create_wsgi_app"]

--- a/website/frontend/__init__.py
+++ b/website/frontend/__init__.py
@@ -64,6 +64,12 @@ def create_app(config_overrides=None):
     # Health check endpoint (/healthz)
     init_healthz(app)
 
+    # Cache-busting for static assets (adds ?v=<content-hash> to static URLs so
+    # a long Cache-Control max-age is safe across releases).
+    from .static_versioning import init_static_versioning
+
+    init_static_versioning(app)
+
     # Template utilities
     app.jinja_env.add_extension('jinja2.ext.do')
 

--- a/website/frontend/static_versioning.py
+++ b/website/frontend/static_versioning.py
@@ -1,0 +1,60 @@
+"""Static asset cache-busting.
+
+Static files are served with a long ``Cache-Control`` max-age (whether by
+granian's static offloading or Flask), which is only safe if the URL changes
+when the file's contents change. Our templates reference assets by plain name
+(``url_for('static', filename=...)``), so on their own the URLs never change
+and a client could serve a stale asset for the whole cache lifetime after a
+release.
+
+This module makes long caching safe by appending a short content-hash query
+argument (``?v=<hash>``) to every ``static`` URL. The query string does not
+affect which file is served (granian and Flask both ignore it), it only changes
+the browser's cache key: when a file changes, its hash changes, the URL
+changes, and the browser refetches.
+
+Hashes are computed lazily on first use and cached in-memory per worker
+process, so there is no per-request disk I/O in the steady state.
+"""
+
+import hashlib
+import os
+import threading
+
+
+def init_static_versioning(app):
+    static_folder = app.static_folder
+    cache = {}
+    lock = threading.Lock()
+
+    def file_hash(filename):
+        """Return a short content hash for a static file, or None if unreadable."""
+        # Cache keyed by filename; value is the hash string (or None).
+        if filename in cache:
+            return cache[filename]
+        digest = None
+        if static_folder:
+            path = os.path.join(static_folder, filename)
+            try:
+                with open(path, 'rb') as fh:
+                    digest = hashlib.md5(fh.read()).hexdigest()[:8]  # noqa: S324 (not security-sensitive)
+            except OSError:
+                digest = None
+        with lock:
+            cache[filename] = digest
+        return digest
+
+    @app.url_defaults
+    def add_static_version(endpoint, values):
+        # Only touch the built-in static endpoint, and only when a filename is
+        # given and no explicit version was already provided.
+        if endpoint != 'static':
+            return
+        filename = values.get('filename')
+        if not filename or 'v' in values:
+            return
+        digest = file_hash(filename)
+        if digest:
+            values['v'] = digest
+
+    return file_hash

--- a/website/frontend/static_versioning_test.py
+++ b/website/frontend/static_versioning_test.py
@@ -1,0 +1,54 @@
+import os
+
+from flask import url_for
+
+from website.frontend import create_app
+
+
+def _app():
+    app = create_app(config_overrides={'TESTING': True, 'SERVER_NAME': 'localhost'})
+    return app
+
+
+def test_static_url_gets_version_query():
+    app = _app()
+    # pick a real static file that ships with the app
+    rel = 'css/styles.css'
+    assert os.path.exists(os.path.join(app.static_folder, rel))
+    with app.test_request_context():
+        url = url_for('static', filename=rel)
+    assert '?v=' in url
+    # 8-char hex hash
+    version = url.split('?v=')[1]
+    assert len(version) == 8
+    assert all(c in '0123456789abcdef' for c in version)
+
+
+def test_static_version_is_stable_for_same_content():
+    app = _app()
+    with app.test_request_context():
+        a = url_for('static', filename='css/styles.css')
+        b = url_for('static', filename='css/styles.css')
+    assert a == b
+
+
+def test_static_version_differs_between_different_files():
+    app = _app()
+    with app.test_request_context():
+        a = url_for('static', filename='css/styles.css')
+        b = url_for('static', filename='js/jquery.min.js')
+    assert a.split('?v=')[1] != b.split('?v=')[1]
+
+
+def test_missing_static_file_gets_no_version():
+    app = _app()
+    with app.test_request_context():
+        url = url_for('static', filename='does/not/exist.css')
+    assert '?v=' not in url
+
+
+def test_explicit_version_is_not_overridden():
+    app = _app()
+    with app.test_request_context():
+        url = url_for('static', filename='css/styles.css', v='custom')
+    assert url.endswith('v=custom')


### PR DESCRIPTION
# Summary

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**: Serve `/static/*` directly from granian (bypassing the Python app) with a long cache lifetime, made safe by content-hash cache-busting on static URLs.

# Problem

Every `/static/*` request currently goes through Flask's WSGI static view — a typical page pulls ~15 assets, each entering the Python interpreter and consuming a blocking thread. granian can serve static files directly from Rust, but its static handler emits only `Cache-Control` (no `ETag`/`Last-Modified`, no conditional requests — verified in-container). Since our templates reference assets by plain name (`url_for('static', filename=...)`), a long `max-age` on its own would risk serving stale CSS/JS for the whole cache lifetime after a release.

# Solution

Two parts:

1. **Cache-busting** (`static_versioning.py`): a Flask `url_defaults` hook appends `?v=<content-hash>` (first 8 hex of the file's md5) to every `static` URL. The query string doesn't change which file is served (granian and Flask ignore it); it only changes the browser cache key, so a changed file gets a new URL and is refetched. Hashes are computed lazily and cached per worker. Missing files and explicit `v=` are left untouched.
2. **Offloading** (Dockerfile): `--static-path-route /static --static-path-mount website/frontend/static`, with `GRANIAN_STATIC_PATH_EXPIRES=2592000` (30 days, overridable). The mount matches Flask's `static_folder`, so generated URLs still resolve.

# Tradeoffs / notes

- Offloaded static requests **no longer appear in the WSGI access log** (they're served in Rust). granian counts them via the `static_requests_handled` metric — surfaced by the companion metrics PR.
- The static handler has no conditional-request support; the `?v=` scheme is what makes the long cache correct, so the two changes must ship together.
- One hardcoded absolute URL in JSON-LD (`base.html` `"screenshot"`) is not a `url_for` call and is intentionally left unversioned.

# Verification

- 95 tests pass (incl. 5 new for the versioning: `?v=` injected, stable per content, differs per file, absent for missing files, explicit `v` preserved). ruff clean.
- In-container: home page emits `/static/...?v=<hash>`; granian serves those with `cache-control: max-age=2592000` and correct content-types; requests with and without `?v` return 200; page renders.

# Action

Second of three granian follow-up PRs. Intended for testing on **beta via the `edge` image** before any release; no version bump.
