### PR TITLE
Enable granian Prometheus metrics exporter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -83,7 +83,6 @@ ENV GRANIAN_BACKPRESSURE=16
 # Both are overridable/disableable at runtime via these GRANIAN_* env vars.
 ENV GRANIAN_LOG_ACCESS_ENABLED=true
 ENV GRANIAN_LOG_ACCESS_FMT="[%(time)s] %(addr)s xff=%(header{x-forwarded-for})s \"%(method)s %(path)s %(protocol)s\" %(status)d %(dt_ms).3f"
-EXPOSE 3031
 # Offload /static/* directly to granian (served from Rust, bypassing the Python
 # app) instead of Flask's static view. The mount path is relative to WORKDIR
 # (/code/website) and matches Flask's static_folder, so url_for('static', ...)
@@ -95,6 +94,15 @@ EXPOSE 3031
 # releases. granian ignores the query string when serving the file. Override
 # GRANIAN_STATIC_PATH_EXPIRES to change the lifetime.
 ENV GRANIAN_STATIC_PATH_EXPIRES=2592000
+# Prometheus metrics exporter on a separate port (granian_* runtime metrics:
+# requests/connections/static/GIL-wait). Bound to 0.0.0.0 so it is reachable
+# for scraping when the port is published; keep it internal-only at the network
+# layer (do not expose 9091 publicly). Port/address/interval are overridable via
+# the GRANIAN_METRICS_* env vars.
+ENV GRANIAN_METRICS_ENABLED=true
+ENV GRANIAN_METRICS_ADDRESS=0.0.0.0
+ENV GRANIAN_METRICS_PORT=9091
+EXPOSE 3031 9091
 CMD ["/code/website/.venv/bin/granian", \
      "--interface", "wsgi", \
      "--factory", \


### PR DESCRIPTION
# Summary

* This is a…
    * [ ] Bug fix
    * [x] Feature addition
    * [ ] Refactoring
    * [ ] Minor / simple change (like a typo)
    * [ ] Other
* **Describe this change in 1-2 sentences**: Enable granian's built-in Prometheus metrics exporter so we get per-worker runtime metrics (requests, connections, GIL-wait, static requests) for the existing telegraf/InfluxDB/Grafana stack.

# Problem

We had no server-level runtime metrics for picard-website. granian ships a Prometheus exporter that exposes useful `granian_*` metrics; it's disabled by default and binds to `127.0.0.1`, so it isn't reachable for scraping out of the box.

# Solution

In the Dockerfile (all overridable via `GRANIAN_METRICS_*`):

```
GRANIAN_METRICS_ENABLED=true
GRANIAN_METRICS_ADDRESS=0.0.0.0   # reachable for scraping when the port is published
GRANIAN_METRICS_PORT=9091         # not 9090, to avoid colliding with a Prometheus server
EXPOSE 3031 9091
```

Metrics exposed include per-worker `requests_handled`, `connections_handled`/`active`, `worker_lifetime`, `blocking_threads`, GIL-wait, and `static_requests_handled` — the last is handy now that static serving is offloaded (those requests no longer show in the access log).

# Verification

In-container: `http://…:9091/` returns 200 `text/plain` in Prometheus format; `granian_requests_handled{worker="N"}` etc. populate per worker after traffic; the app keeps serving on 3031.

# Action

Third of three granian follow-up PRs. Testable on **beta via the `edge` image**; no version bump.

**Deploy-side follow-up (docker-server-configs):** to actually scrape it, `start_picard_website` needs to publish 9091 and register it in consul (the `SERVICE_9091_*` pattern), kept internal-only — the metrics port must not be exposed publicly. I can prepare that PR once this is reviewed.
